### PR TITLE
nvidia compiler

### DIFF
--- a/arch/nvidia.defs
+++ b/arch/nvidia.defs
@@ -1,0 +1,5 @@
+F90=mpif90
+FFLAGS = -c
+#F90FLAGS = -cpp -mp -Mfree -O3 
+F90FLAGS = -cpp  -Mfree -O3 
+LINK= $(F90)  $(F90FLAGS)

--- a/arch/nvidiadebug.defs
+++ b/arch/nvidiadebug.defs
@@ -1,0 +1,6 @@
+F90=mpif90
+FFLAGS = -c
+F90FLAGS = -cpp -mp -Mfree  -g -traceback 
+#F90FLAGS = -cpp -mp -Mfree -C -g -traceback 
+#F90FLAGS = -cpp  -Mfree  -g -traceback 
+LINK= $(F90)  $(F90FLAGS)

--- a/src/amrvac.t
+++ b/src/amrvac.t
@@ -385,7 +385,9 @@ contains
     do ifile=nfile,1,-1
        if(itsavelast(ifile)<it) call saveamrfile(ifile)
     end do
-    if (mype==0) call MPI_FILE_CLOSE(log_fh,ierrmpi)
+    if (mype==0 .and. log_fh > 0) then
+      call MPI_FILE_CLOSE(log_fh,ierrmpi)
+    endif
     timeio_tot=timeio_tot+(MPI_WTIME()-timeio0)
 
     if (mype==0) then

--- a/src/modules/mod_random.t
+++ b/src/modules/mod_random.t
@@ -2,6 +2,8 @@
 !> generator is the xoroshiro128plus method.
 module mod_random
 
+#include "amrvac.h"
+
   implicit none
   private
 
@@ -44,6 +46,59 @@ module mod_random
   public :: prng_t
 
 contains
+
+
+#if defined(__NVCOMPILER) ||  (defined(USE_INTRINSIC_SHIFT) && USE_INTRINSIC_SHIFT==0)
+
+  !> added for nvidia compilers
+   function shiftl(val, shift) result(res_value)
+    integer(i8), intent(in) :: val
+    integer, intent(in) :: shift
+    integer(i8) :: res_value
+!    integer(i8),parameter :: bit_mask1=9223372036854775807
+!    !b'0111111111111111111111111111111111111111111111111111111111111111'
+!    integer(i8),parameter :: bit_mask2=-9223372036854775808   
+!    !b'1000000000000000000000000000000000000000000000000000000000000000'
+    integer(i8) :: bit_mask1, bit_mask2
+
+    ! cannot be initialized with b values in gnu, cannot have the big decimal numbers in nvidia 
+    bit_mask1=huge(val)
+    bit_mask2=-bit_mask1-1
+
+
+    if(val<0) then
+      res_value = ior(lshift(iand(val, bit_mask1), shift),bit_mask2)
+    else
+      res_value = lshift(val, shift)
+    endif  
+
+  end function shiftl
+
+
+   function shiftr(val, shift) result(res_value)
+    integer(i8), intent(in) :: val
+    integer, intent(in) :: shift
+    integer(i8) :: res_value
+!    integer(i8),parameter :: bit_mask1=9223372036854775807
+!    !b'0111111111111111111111111111111111111111111111111111111111111111'
+!    integer(i8),parameter :: bit_mask2=-9223372036854775808   
+!    !b'1000000000000000000000000000000000000000000000000000000000000000'
+    integer(i8) :: bit_mask1, bit_mask2
+
+    ! cannot be initialized with b values in gnu, cannot have the big decimal numbers in nvidia 
+    bit_mask1=huge(val)
+    bit_mask2=-bit_mask1-1
+
+    if(val<0) then
+      res_value = ior(rshift(iand(val, bit_mask1), shift),bit_mask2)
+    else
+      res_value = rshift(val, shift)
+    endif  
+    
+  end function shiftr
+
+#endif
+
 
   !> Initialize a collection of rng's for parallel use
   subroutine init_parallel(self, n_proc, rng)


### PR DESCRIPTION
1) added new files with compiler flags nvidia and nvidiadebug
-C flag which checks array bounds in 1D (mod_thermal_emission.f) gives a segmetation fault at compilation (probably because a 0 size array)
2) shiftr and shiftl are implemented in mod_random.t using rshift and lshift when nvidia compiler is used or when it is explicitly set USE_INTRINSIC_SHIFT=0 in amrvac.h
3) there was a bug in amrvac.t which tried to close an unopened log  file for regression tests  
The tests which use supertimestepping fail (a compiler bug?)