### PR TITLE
Mac build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: tests
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
   pull_request:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,6 @@ jobs:
         include:
           - os: ubuntu-20.04
             compiler: gfortran-8  # not longer supported for ubuntu-22
-          - os: macos-11
-            compiler: gfortran-11
-            gcc_name: gcc@11
           - os: macos-12
             compiler: gfortran-11
             gcc_name: gcc@11

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
-# MPI-AMRVAC ![Build Status](https://travis-ci.org/amrvac/amrvac.svg?branch=master)
+[![tests](https://github.com/amrvac/AGILE-experimental/actions/workflows/tests.yml/badge.svg)](https://github.com/amrvac/AGILE-experimental/actions/workflows/tests.yml)
+
+# MPI-AMRVAC 
 
 This is the latest version of MPI-AMRVAC. All documentation is available on [amrvac.org](http://amrvac.org/).


### PR DESCRIPTION
This PR:

- removes the failing testing for macos-11, leaving only the testing for macos-12
- adds the option to manually trigger workflow runs on GitHub
- fixes the test status badge in the Readme

fixes #22 