### PR TITLE
Multiblock nan issue resolved

### DIFF
--- a/src/amr/mod_amr_solution_node.t
+++ b/src/amr/mod_amr_solution_node.t
@@ -79,9 +79,6 @@ contains
     double precision :: xc(ixGlo1:ixGhi1),delxc(ixGlo1:ixGhi1)
     double precision :: exp_factor_coarse(ixGlo1:ixGhi1),del_exp_factor_coarse(ixGlo1:ixGhi1),exp_factor_primitive_coarse(ixGlo1:ixGhi1)
 
-    !opedit: debug:
-    integer     :: idbg
-    
     ixCoGmin^D=1;
     ixCoGmax^D=(ixGhi^D-2*nghostcells)/2+2*nghostcells;
   
@@ -105,13 +102,7 @@ contains
     if(.not. associated(ps(igrid)%w)) then
        
        ! allocate arrays for solution and space
-       do idbg=1,igrid-1
-          print *, 'alloc_node pre  alloc_state', igrid, idbg, ps(idbg)%w(4,4,1), bg(1)%w(4,4,1,idbg)
-       end do
        call alloc_state(igrid, ps(igrid), ixG^LL, ixGext^L, .true.)
-       do idbg=1,igrid
-          print *, 'alloc_node post alloc_state', igrid, idbg, ps(idbg)%w(4,4,1), bg(1)%w(4,4,1,idbg)
-       end do
        ! allocate arrays for one level coarser solution
        call alloc_state_coarse(igrid, psc(igrid), ixCoG^L, ixCoG^L)
        if(.not.convert) then
@@ -601,16 +592,10 @@ contains
     integer             :: idbg
   
     !allocate(s%w(ixG^S,1:nw))
-    do idbg=1,igrid-1
-       print *, 'alloc_state A', s%istep, igrid, idbg, bg(s%istep)%w(4,4,1,idbg), ps(idbg)%w(4,4,1), associated(s%w)
-    end do
     s%w => bg(s%istep)%w(:^D&,:,igrid)
     s%igrid=igrid
     s%w=0.d0
     s%ixG^L=ixG^L;
-    do idbg=1,igrid
-       print *, 'alloc_state B', s%istep, igrid, idbg, bg(s%istep)%w(4,4,1,idbg), ps(idbg)%w(4,4,1), s%w(4,4,1)
-    end do
     {^D& ixGsmin^D = ixGmin^D-1; ixGsmax^D = ixGmax^D|;}
     if(stagger_grid) then
       allocate(s%ws(ixGs^S,1:nws))

--- a/src/amr/mod_amr_solution_node.t
+++ b/src/amr/mod_amr_solution_node.t
@@ -16,8 +16,6 @@ contains
     use mod_forest, only: igrid_inuse
     use mod_global_parameters
 
-    !$acc declare present(node)
-
     integer, intent(in) :: ipe
     integer :: igrid, igrid_available
   
@@ -69,8 +67,6 @@ contains
     use mod_physics, only: phys_set_equi_vars
     use mod_b0, only: set_B0_grid 
     
-    !$acc declare present(node)
-
     integer, intent(in) :: igrid
   
     integer :: level, ig^D, ign^D, ixCoG^L, ix, i^D
@@ -82,7 +78,10 @@ contains
     double precision :: exp_factor_ext(ixGlo1-1:ixGhi1+1),del_exp_factor_ext(ixGlo1-1:ixGhi1+1),exp_factor_primitive_ext(ixGlo1-1:ixGhi1+1)
     double precision :: xc(ixGlo1:ixGhi1),delxc(ixGlo1:ixGhi1)
     double precision :: exp_factor_coarse(ixGlo1:ixGhi1),del_exp_factor_coarse(ixGlo1:ixGhi1),exp_factor_primitive_coarse(ixGlo1:ixGhi1)
-  
+
+    !opedit: debug:
+    integer     :: idbg
+    
     ixCoGmin^D=1;
     ixCoGmax^D=(ixGhi^D-2*nghostcells)/2+2*nghostcells;
   
@@ -106,7 +105,13 @@ contains
     if(.not. associated(ps(igrid)%w)) then
        
        ! allocate arrays for solution and space
+       do idbg=1,igrid-1
+          print *, 'alloc_node pre  alloc_state', igrid, idbg, ps(idbg)%w(4,4,1), bg(1)%w(4,4,1,idbg)
+       end do
        call alloc_state(igrid, ps(igrid), ixG^LL, ixGext^L, .true.)
+       do idbg=1,igrid
+          print *, 'alloc_node post alloc_state', igrid, idbg, ps(idbg)%w(4,4,1), bg(1)%w(4,4,1,idbg)
+       end do
        ! allocate arrays for one level coarser solution
        call alloc_state_coarse(igrid, psc(igrid), ixCoG^L, ixCoG^L)
        if(.not.convert) then
@@ -592,12 +597,20 @@ contains
     integer, intent(in) :: igrid, ixG^L, ixGext^L
     logical, intent(in) :: alloc_once_for_ps
     integer             :: ixGs^L
+    !opedit: debug:
+    integer             :: idbg
   
     !allocate(s%w(ixG^S,1:nw))
+    do idbg=1,igrid-1
+       print *, 'alloc_state A', s%istep, igrid, idbg, bg(s%istep)%w(4,4,1,idbg), ps(idbg)%w(4,4,1), associated(s%w)
+    end do
     s%w => bg(s%istep)%w(:^D&,:,igrid)
     s%igrid=igrid
     s%w=0.d0
     s%ixG^L=ixG^L;
+    do idbg=1,igrid
+       print *, 'alloc_state B', s%istep, igrid, idbg, bg(s%istep)%w(4,4,1,idbg), ps(idbg)%w(4,4,1), s%w(4,4,1)
+    end do
     {^D& ixGsmin^D = ixGmin^D-1; ixGsmax^D = ixGmax^D|;}
     if(stagger_grid) then
       allocate(s%ws(ixGs^S,1:nws))

--- a/src/amr/mod_initialize_amr.t
+++ b/src/amr/mod_initialize_amr.t
@@ -66,16 +66,8 @@ contains
                        MPI_SUM,icomm,ierrmpi)
     }
   
-    print *, 'initlevelone pre-getbc', 1, ps(1)%w(4,4,1), bg(1)%w(4,4,1,1)
-    print *, 'initlevelone pre-getbc', 2, ps(2)%w(4,4,1), bg(1)%w(4,4,1,2)
-    print *, 'initlevelone pre-getbc', 3, ps(3)%w(4,4,1), bg(1)%w(4,4,1,3)
-    print *, 'initlevelone pre-getbc', 4, ps(4)%w(4,4,1), bg(1)%w(4,4,1,4)
     ! update ghost cells
     call getbc(global_time,0.d0,ps,iwstart,nwgc)
-    print *, 'initlevelone getbc', 1, ps(1)%w(4,4,1), bg(1)%w(4,4,1,1)
-    print *, 'initlevelone getbc', 2, ps(2)%w(4,4,1), bg(1)%w(4,4,1,2)
-    print *, 'initlevelone getbc', 3, ps(3)%w(4,4,1), bg(1)%w(4,4,1,3)
-    print *, 'initlevelone getbc', 4, ps(4)%w(4,4,1), bg(1)%w(4,4,1,4)
     
   end subroutine initlevelone
   

--- a/src/amr/mod_initialize_amr.t
+++ b/src/amr/mod_initialize_amr.t
@@ -23,6 +23,8 @@ contains
     use mod_amr_solution_node, only: alloc_node
  
     integer :: iigrid, igrid{#IFDEF EVOLVINGBOUNDARY , Morton_no}
+    !opedit: debug
+    integer :: idebg
   
     levmin=1
     levmax=1
@@ -34,9 +36,25 @@ contains
   
     ! fill solution space of all root grids
     do iigrid=1,igridstail; igrid=igrids(iigrid);
+
+       do idebg=1,igrid-1
+          print *, 'initlevelone pre-alloc_node', idebg, ps(idebg)%w(4,4,1), bg(1)%w(4,4,1,idebg)
+       end do
+
        call alloc_node(igrid)
+
+       do idebg=1,igrid
+          print *, 'initlevelone post-alloc_node', idebg, ps(idebg)%w(4,4,1), bg(1)%w(4,4,1,idebg)
+       end do
+
        ! in case gradient routine used in initial condition, ensure geometry known
        call initial_condition(igrid)
+       print *, 'initlevelone current igrid', igrid, ps(igrid)%w(4,4,1), bg(1)%w(4,4,1,igrid)
+
+       do idebg=1,igrid
+          print *, 'initlevelone', idebg, ps(idebg)%w(4,4,1), bg(1)%w(4,4,1,idebg)
+       end do
+       
     end do
     {#IFDEF EVOLVINGBOUNDARY
     ! mark physical-boundary blocks on space-filling curve
@@ -48,9 +66,17 @@ contains
                        MPI_SUM,icomm,ierrmpi)
     }
   
+    print *, 'initlevelone pre-getbc', 1, ps(1)%w(4,4,1), bg(1)%w(4,4,1,1)
+    print *, 'initlevelone pre-getbc', 2, ps(2)%w(4,4,1), bg(1)%w(4,4,1,2)
+    print *, 'initlevelone pre-getbc', 3, ps(3)%w(4,4,1), bg(1)%w(4,4,1,3)
+    print *, 'initlevelone pre-getbc', 4, ps(4)%w(4,4,1), bg(1)%w(4,4,1,4)
     ! update ghost cells
     call getbc(global_time,0.d0,ps,iwstart,nwgc)
-  
+    print *, 'initlevelone getbc', 1, ps(1)%w(4,4,1), bg(1)%w(4,4,1,1)
+    print *, 'initlevelone getbc', 2, ps(2)%w(4,4,1), bg(1)%w(4,4,1,2)
+    print *, 'initlevelone getbc', 3, ps(3)%w(4,4,1), bg(1)%w(4,4,1,3)
+    print *, 'initlevelone getbc', 4, ps(4)%w(4,4,1), bg(1)%w(4,4,1,4)
+    
   end subroutine initlevelone
   
   !> fill in initial condition

--- a/src/amr/mod_initialize_amr.t
+++ b/src/amr/mod_initialize_amr.t
@@ -37,23 +37,10 @@ contains
     ! fill solution space of all root grids
     do iigrid=1,igridstail; igrid=igrids(iigrid);
 
-       do idebg=1,igrid-1
-          print *, 'initlevelone pre-alloc_node', idebg, ps(idebg)%w(4,4,1), bg(1)%w(4,4,1,idebg)
-       end do
-
        call alloc_node(igrid)
-
-       do idebg=1,igrid
-          print *, 'initlevelone post-alloc_node', idebg, ps(idebg)%w(4,4,1), bg(1)%w(4,4,1,idebg)
-       end do
 
        ! in case gradient routine used in initial condition, ensure geometry known
        call initial_condition(igrid)
-       print *, 'initlevelone current igrid', igrid, ps(igrid)%w(4,4,1), bg(1)%w(4,4,1,igrid)
-
-       do idebg=1,igrid
-          print *, 'initlevelone', idebg, ps(idebg)%w(4,4,1), bg(1)%w(4,4,1,idebg)
-       end do
        
     end do
     {#IFDEF EVOLVINGBOUNDARY

--- a/src/amr/mod_selectgrids.t
+++ b/src/amr/mod_selectgrids.t
@@ -7,7 +7,6 @@ module mod_selectgrids
  
 contains
 
-
   !=============================================================================
   subroutine selectgrids
   
@@ -51,7 +50,10 @@ contains
         igridstail_passive = kgrid
   
   !     Check if user wants to deactivate grids at all and return if not:
-        if (userflag == -1) return
+        if (userflag == -1) then
+           !$acc update device(igrids_active, igrids_passive, igridstail_active, igridstail_passive)
+           return
+        end if
   
   !     Got the passive grids. 
   !     Now, we re-activate a safety belt of radius nsafety blocks.
@@ -108,14 +110,9 @@ contains
               end if
            end do
         end do
-  
-  !     Just for output and testing: 
-  !      ixO^L=ixG^LL^LSUBnghostcells;      
-  !      do iigrid=1,igridstail; igrid=igrids(iigrid);        
-  !         ps(igrid)%w(ixO^S,flg_) = dble(isafety(igrid,mype))
-  !         ps(igrid)%w(ixO^S,cpu_) = dble(mype)
-  !      end do
-  
+
+        !$acc update device(igrids_active, igrids_passive, igridstail_active, igridstail_passive)
+        
         contains
   !=============================================================================
   subroutine set_neighbor_state(igrid)

--- a/src/hd/mod_hd_phys.t
+++ b/src/hd/mod_hd_phys.t
@@ -307,7 +307,9 @@ contains
     phys_handle_small_values => hd_handle_small_values
 
     ! Whether diagonal ghost cells are required for the physics
-    phys_req_diagonal = .false.
+    !opedit: debug corner issue
+!    phys_req_diagonal = .false.
+    phys_req_diagonal = .true.
 
     ! derive units from basic units
     call hd_physical_units()

--- a/src/hd/mod_hd_phys.t
+++ b/src/hd/mod_hd_phys.t
@@ -307,9 +307,7 @@ contains
     phys_handle_small_values => hd_handle_small_values
 
     ! Whether diagonal ghost cells are required for the physics
-    !opedit: debug corner issue
-!    phys_req_diagonal = .false.
-    phys_req_diagonal = .true.
+    phys_req_diagonal = .false.
 
     ! derive units from basic units
     call hd_physical_units()

--- a/src/mod_advance.t
+++ b/src/mod_advance.t
@@ -247,10 +247,8 @@ contains
         qdt, dtfactor, &                ! some scalars related to time stepping
         ixG^LL,ixO^L, idim^LIM, &      ! bounds for some arrays
         qtC, &                          ! scalar related to time stepping
-        psa, &
         bga, &                          ! first block grid
         qt,  &                          ! scalar related to time stepping
-        psb, &
         bgb, &                          ! second block grid
         fC, fE &                        ! fluxes
     )

--- a/src/mod_connectivity.t
+++ b/src/mod_connectivity.t
@@ -19,10 +19,13 @@ module mod_connectivity
    integer, dimension(:), allocatable :: igrids
    integer, dimension(:), allocatable :: igrids_active
    integer, dimension(:), allocatable :: igrids_passive
+   !$acc declare create(igrids, igrids_active, igrids_passive)
+   
    ! number of grids on current processor
    integer :: igridstail
    integer :: igridstail_active
    integer :: igridstail_passive
+   !$acc declare create(igridstail, igridstail_active, igridstail_passive)
 
    integer, dimension(^ND) :: nrecv_fc, nsend_fc
    ! cc for corner coarse

--- a/src/mod_finite_volume_all.t
+++ b/src/mod_finite_volume_all.t
@@ -162,9 +162,6 @@ contains
 
             end do ! Next idims
 
-            call addsource2(qdt*dble(idimsmax - idimsmin + 1)/dble(ndim), &
-                            dtfactor*dble(idimsmax - idimsmin + 1)/dble(ndim), &
-                            ixI^L, ixO^L, 1, nw, qtC, wCT, wprim, qt, wnew, x, .false., active)
          end associate
       end do   ! igrid
 
@@ -179,7 +176,6 @@ contains
       use mod_comm_lib, only: mpistop
       use mod_hd_phys, only: hd_to_conserved_gpu
 
-      !$acc declare present(node)
       !$acc routine
 
       integer, value, intent(in) :: ixI^L, ixL^L, ixR^L, idims, igrid

--- a/src/mod_finite_volume_all.t
+++ b/src/mod_finite_volume_all.t
@@ -22,56 +22,43 @@ contains
    !AGILE
    !> finite volume method computing all blocks
    subroutine finite_volume_all(method, qdt, dtfactor, ixI^L, ixO^L, idims^LIM, &
-                                qtC, psa, bga, qt, psb, bgb, fC, fE)
+                                qtC, bga, qt, bgb, fC, fE)
       use mod_physics
       use mod_variables
       use mod_global_parameters
-      !opedit: FIXME has internal procedure pointers, used for roe solvers, not implemented:
-!    use mod_tvd, only:tvdlimit2
       use mod_source, only: addsource2
       use mod_usr_methods
       use mod_comm_lib, only: mpistop
-      use mod_hd_phys!, only: hd_get_flux_gpu, hd_to_primitive_gpu, hd_get_cbounds_gpu, hd_to_conserved_gpu
+      use mod_hd_phys
 
       integer, intent(in)                                   :: method
       double precision, intent(in)                          :: qdt, dtfactor, qtC, qt
       integer, intent(in)                                   :: ixI^L, ixO^L, idims^LIM
-      type(state), target                                   :: psa(max_blocks)
-      type(state), target                                   :: psb(max_blocks)
-      type(block_grid_t)                            :: bga
-      type(block_grid_t)                            :: bgb
-      double precision, dimension(ixI^S, 1:nwflux, 1:ndim)    :: fC
-      double precision, dimension(ixI^S, sdim:3)             :: fE
+      type(block_grid_t)                                    :: bga
+      type(block_grid_t)                                    :: bgb
+      double precision, dimension(ixI^S, 1:nwflux, 1:ndim)  :: fC
+      double precision, dimension(ixI^S, sdim:3)            :: fE
 
       ! primitive w at cell center
-      double precision, dimension(ixI^S, 1:nw) :: wprim
+      double precision, dimension(ixI^S, 1:nw)       :: wprim
       ! left and right constructed status in conservative form
-      double precision, dimension(ixI^S, 1:nw) :: wLC, wRC
+      double precision, dimension(ixI^S, 1:nw)       :: wLC, wRC
       ! left and right constructed status in primitive form, needed for better performance
-      double precision, dimension(ixI^S, 1:nw) :: wLp, wRp
+      double precision, dimension(ixI^S, 1:nw)       :: wLp, wRp
       !$acc declare create(wprim, wLC, wRC, wLp, wRp)
-      double precision, dimension(ixI^S, 1:nwflux) :: fLC, fRC
+      double precision, dimension(ixI^S, 1:nwflux)   :: fLC, fRC
       !$acc declare create(fLC, fRC)
       double precision, dimension(ixI^S, 1:number_species)      :: cmaxC
       double precision, dimension(ixI^S, 1:number_species)      :: cminC
       double precision, dimension(ixI^S, 1:number_species)      :: Hspeed
       !$acc declare create(cmaxC, cminC, Hspeed)
-      double precision, dimension(ixO^S)      :: inv_volume
-      double precision, dimension(1:ndim)     :: dxinv
-      integer, dimension(ixI^S)               :: patchf
-      integer :: idims, iw, ix^L, hxO^L, ixC^L, ixCR^L, kxC^L, kxR^L, ii
-      logical :: active
-      type(ct_velocity) :: vcts
-      integer :: ix^D
-      double precision, dimension(ixI^S, 1:nwflux)     :: whll, Fhll, fCD
-      double precision, dimension(ixI^S)              :: lambdaCD
-      integer  :: igrid, iigrid, ia, ib
-
+      double precision, dimension(1:ndim)        :: dxinv
+      integer                                    :: idims, iw, ix^L, hxO^L, ixC^L, ixCR^L, kxC^L, kxR^L, ii
+      integer                                    :: ix^D
+      integer                                    :: igrid, iigrid, ia, ib
       double precision, dimension(ixI^S, 1:ndim) :: x
-      double precision                          :: dxs(ndim)
+      double precision                           :: dxs(ndim)
       !$acc declare create(dxs,dxinv)
-      !opedit debug:
-      integer         :: idbg^D
 
       ia = bga%istep; ib = bgb%istep ! remember, old names map as: wCT => bga, wnew => bgb
 
@@ -82,283 +69,94 @@ contains
          x = ps(igrid)%x
          dxs = rnode(rpdx1_:rnodehi, igrid)
 
-!         associate (wCT => bga%w(:^D&, :, igrid), wnew => bgb%w(:^D&, :, igrid))
-           
-           print *, 'fvolume_all A:', igrid, maxval(bg(ib)%w(:,:,1,igrid)), maxval(bg(ia)%w(:,:,1,igrid))
-            ! if (any(wnew(:,:,1) .ne. wnew(:,:,1)) ) then
-            !    print *, 'NaN found in wnew A'
-            !    do idbg2=ixImin2,ixImax2
-            !       do idbg1=ixImin1,ixImax1
-            !          print *, idbg1, idbg2, wnew(idbg1,idbg2,1)
-            !       end do
-            !    end do
-            ! end if
-            if (any(bg(ib)%w(:,:,1,igrid) .ne. bg(ib)%w(:,:,1,igrid)) )  then
-            print *, 'NaN found in wnew A'
-            print *, igrid, 'wnew A',ixImin1,ixImax1,ixImin2,ixImax2
-               do idbg2=ixImin2,ixImax2
-                  do idbg1=ixImin1,ixImax1
-                     print *, igrid, idbg1, idbg2, bg(ib)%w(idbg1,idbg2,1,igrid)
-                  end do
+         ! The flux calculation contracts by one in the idims direction it is applied.
+         ! The limiter contracts the same directions by one more, so expand ixO by 2.
+         ix^L=ixO^L; 
+         do idims = idims^LIM
+            ix^L=ix^L^LADD2*kr(idims,^D); 
+         end do
+         if (ixI^L^LTix^L|.or.|.or.) &
+              call mpistop("Error in fv : Nonconforming input limits")
+
+         fC = 0.d0     
+         fLC = 0.d0
+         fRC = 0.d0
+
+         wprim = bg(ia)%w(:^D&, :, igrid)
+
+         call hd_to_primitive_gpu(ixI^L, ixI^L, wprim, x)
+
+         do idims = idims^LIM
+            ! use interface value of w0 at idims
+            b0i = idims
+
+            hxO^L=ixO^L-kr(idims,^D); 
+            kxCmin^D=ixImin^D;kxCmax^D=ixImax^D-kr(idims,^D); 
+            kxR^L=kxC^L+kr(idims,^D); 
+            ! ixC is centered index in the idims direction from ixOmin-1/2 to ixOmax+1/2
+            ixCmax^D=ixOmax^D;ixCmin^D=hxOmin^D; 
+
+            ! wRp and wLp are defined at the same locations, and will correspond to
+            ! the left and right reconstructed values at a cell face. Their indexing
+            ! is similar to cell-centered values, but in direction idims they are
+            ! shifted half a cell towards the 'lower' direction.
+
+            wRp(kxC^S,1:nw)=wprim(kxR^S,1:nw)
+            wLp(kxC^S,1:nw)=wprim(kxC^S,1:nw)
+
+
+            ! Determine stencil size
+            {ixCRmin^D = max(ixCmin^D - phys_wider_stencil,ixGlo^D) \}
+            {ixCRmax^D = min(ixCmax^D + phys_wider_stencil,ixGhi^D) \}
+
+            ! apply limited reconstruction for left and right status at cell interfaces
+            call reconstruct_LR_gpu(ixI^L, ixCR^L, ixCR^L, idims, wprim, wLC, wRC, wLp, wRp, x, dxs(idims), igrid)
+
+            ! evaluate physical fluxes according to reconstructed status
+            call hd_get_flux_gpu(wLC, wLp, x, ixI^L, ixC^L, idims, fLC)
+            call hd_get_flux_gpu(wRC, wRp, x, ixI^L, ixC^L, idims, fRC)
+
+            ! get the min and max characteristic velocities
+            call hd_get_cbounds_gpu(wLC, wRC, wLp, wRp, x, ixI^L, ixC^L, idims, Hspeed, cmaxC, cminC)
+
+            ! use approximate Riemann solver to get flux at interfaces
+            do ii = 1, number_species
+               do iw = start_indices(ii), stop_indices(ii)
+                  {do ix^DB = ixCmin^DB, ixCmax^DB\}
+                  if (cminC(ix^D, ii) >= zero) then
+                     fC(ix^D, iw, idims) = fLC(ix^D, iw)
+                  else if (cmaxC(ix^D, ii) <= zero) then
+                     fC(ix^D, iw, idims) = fRC(ix^D, iw)
+                  else
+                     ! Add hll dissipation to the flux
+                     fC(ix^D, iw, idims) = (cmaxC(ix^D, ii)*fLC(ix^D, iw) - cminC(ix^D, ii)*fRC(ix^D, iw) &
+                          + cminC(ix^D, ii)*cmaxC(ix^D, ii)*(wRC(ix^D, iw) - wLC(ix^D, iw))) &
+                          /(cmaxC(ix^D, ii) - cminC(ix^D, ii))
+                  end if
+                  {end do\}
                end do
-            end if
-           
-            ! The flux calculation contracts by one in the idims direction it is applied.
-            ! The limiter contracts the same directions by one more, so expand ixO by 2.
-            ix^L=ixO^L; 
-            do idims = idims^LIM
-               ix^L=ix^L^LADD2*kr(idims,^D); 
             end do
-            if (ixI^L^LTix^L|.or.|.or.) &
-               call mpistop("Error in fv : Nonconforming input limits")
 
-            ! no longer !$acc kernels present(fC, wCT)
-            fC = 0.d0     ! this is updated every loop iteration (eg l293),
-            ! how to then parallelize?
-            fLC = 0.d0
-            fRC = 0.d0
 
-            wprim = bg(ia)%w(:^D&, :, igrid)
-            ! no longer !$acc end kernels
+         end do ! Next idims
 
-            call hd_to_primitive_gpu(ixI^L, ixI^L, wprim, x)
-            print *, 'hd_gamma:', igrid, hd_gamma
-            
-            if (any(wprim(ixI^S,p_) .le. 0.0d0) ) then
-               print *, igrid, 'negative pressure found A-2'
-               do idbg2=ixImin2,ixImax2
-                  do idbg1=ixImin1,ixImax1
-                     if (wprim(idbg1,idbg2,p_) .lt. 0) then
-                        write(*,*), 'wprim p', igrid, idbg1, idbg2, wprim(idbg1,idbg2,p_)
-                     end if
-                  end do
-               end do
-            end if
+         b0i = 0
+         dxinv = -qdt/dxs
+         do idims = idims^LIM
+            hxO^L=ixO^L-kr(idims,^D); 
+            fC(ixI^S, 1:nwflux, idims)=dxinv(idims)*fC(ixI^S, 1:nwflux, idims)
 
-            if (any(wprim(ixI^S,1) .ne. wprim(ixI^S,1)) ) then
-               print *, igrid, 'NaN found in wprim'
-               do idbg2=ixImin2,ixImax2
-                  do idbg1=ixImin1,ixImax1
-                     if (wprim(idbg1,idbg2,1) .ne. wprim(idbg1,idbg2,1)) then
-                        write(*,*), 'wp', igrid, idbg1, idbg2, wprim(idbg1,idbg2,1)
-                     end if
-                  end do
-               end do
-            end if
+            bg(ib)%w(ixO^S, iwstart:nwflux, igrid) = bg(ib)%w(ixO^S, iwstart:nwflux, igrid) + &
+                 (fC(ixO^S, iwstart:nwflux, idims) - fC(hxO^S, iwstart:nwflux, idims))
 
-            do idims = idims^LIM
-               ! use interface value of w0 at idims
-               b0i = idims
+         end do ! Next idims
 
-               hxO^L=ixO^L-kr(idims,^D); 
-               kxCmin^D=ixImin^D;kxCmax^D=ixImax^D-kr(idims,^D); 
-               kxR^L=kxC^L+kr(idims,^D); 
-               ! ixC is centered index in the idims direction from ixOmin-1/2 to ixOmax+1/2
-               ixCmax^D=ixOmax^D;ixCmin^D=hxOmin^D; 
-
-               ! wRp and wLp are defined at the same locations, and will correspond to
-               ! the left and right reconstructed values at a cell face. Their indexing
-               ! is similar to cell-centered values, but in direction idims they are
-               ! shifted half a cell towards the 'lower' direction.
-
-               wRp(kxC^S,1:nw)=wprim(kxR^S,1:nw)
-               wLp(kxC^S,1:nw)=wprim(kxC^S,1:nw)
-
-               
-               if (any(wRp(kxC^S,p_) .le. 0.0d0) .or. any(wLp(kxC^S,p_) .le. 0.0d0)) then
-                  print *, igrid, 'negative pressure found A-1'
-                  do idbg2=kxCmin2,kxCmax2
-                     do idbg1=kxCmin1,kxCmax1
-                        if (wRp(idbg1,idbg2,p_) .le. 0.0d0 .or. wLp(idbg1,idbg2,p_) .le. 0.0d0) then
-                           write(*,*), 'pR', igrid, idbg1, idbg2, wRp(idbg1,idbg2,p_)
-                           write(*,*), 'pL', igrid, idbg1, idbg2, wLp(idbg1,idbg2,p_)
-                        end if
-                     end do
-                  end do
-               end if
-
-               
-               ! Determine stencil size
-               ! FIXME: here `phys_wider_stencil` is an integer, not a function pointer
-               {ixCRmin^D = max(ixCmin^D - phys_wider_stencil,ixGlo^D) \}
-               {ixCRmax^D = min(ixCmax^D + phys_wider_stencil,ixGhi^D) \}
-
-               ! apply limited reconstruction for left and right status at cell interfaces
-               call reconstruct_LR_gpu(ixI^L, ixCR^L, ixCR^L, idims, wprim, wLC, wRC, wLp, wRp, x, dxs(idims), igrid)
-               
-               if (any(wLC(ixCR^S,1) .ne. wLC(ixCR^S,1)) .or. any(wLp(ixCR^S,1) .ne. wLp(ixCR^S,1)) ) then
-                  print *, igrid, 'NaN found in wLC'
-                  do idbg2=ixCRmin2,ixCRmax2
-                     do idbg1=ixCRmin1,ixCRmax1
-                        if (wLC(idbg1,idbg2,1) .ne. wLC(idbg1,idbg2,1) .or. wLp(idbg1,idbg2,1) .ne. wLp(idbg1,idbg2,1) ) then
-                           write(*,*), 'wLC', igrid, idbg1, idbg2, wLC(idbg1,idbg2,1)
-                           write(*,*), 'wLp', igrid, idbg1, idbg2, wLp(idbg1,idbg2,1)
-                        end if
-                     end do
-                  end do
-               end if
-               
-               if (any(wRC(ixCR^S,1) .ne. wRC(ixCR^S,1)) .or. any(wRp(ixCR^S,1) .ne. wRp(ixCR^S,1))) then
-                  print *, igrid, 'NaN found in wRC'
-                  do idbg2=ixCRmin2,ixCRmax2
-                     do idbg1=ixCRmin1,ixCRmax1
-                        if (wRC(idbg1,idbg2,1) .ne. wRC(idbg1,idbg2,1) .or. wRp(idbg1,idbg2,1) .ne. wRp(idbg1,idbg2,1) ) then
-                           write(*,*), 'wRC', igrid, idbg1, idbg2, wRC(idbg1,idbg2,1)
-                           write(*,*), 'wRp', igrid, idbg1, idbg2, wRp(idbg1,idbg2,1)
-                        end if
-                     end do
-                  end do
-               end if
-
-               
-               if (any(wRp(ixCR^S,p_) .le. 0.0d0) .or. any(wLp(ixCR^S,p_) .le. 0.0d0)) then
-                  print *, igrid, 'negative pressure found A'
-                  do idbg2=ixCRmin2,ixCRmax2
-                     do idbg1=ixCRmin1,ixCRmax1
-                        if (wRp(idbg1,idbg2,p_) .le. 0.0d0 .or. wLp(idbg1,idbg2,p_) .le. 0.0d0) then
-                           write(*,*), 'pR', igrid, idbg1, idbg2, wRp(idbg1,idbg2,p_)
-                           write(*,*), 'pL', igrid, idbg1, idbg2, wLp(idbg1,idbg2,p_)
-                        end if
-                     end do
-                  end do
-               end if
-
-               ! evaluate physical fluxes according to reconstructed status
-               call hd_get_flux_gpu(wLC, wLp, x, ixI^L, ixC^L, idims, fLC)
-
-               if (any(fLC(ixC^S,1) .ne. fLC(ixC^S,1)) ) then
-                  print *, 'NaN found in fLC', idims
-                  do idbg2=ixCmin2,ixCmax2
-                     do idbg1=ixCmin1,ixCmax1
-                        if (fLC(idbg1,idbg2,1) .ne. fLC(idbg1,idbg2,1)) then
-                           write(*,*), 'FLC', igrid, idbg1, idbg2, fLC(idbg1,idbg2,1)
-                        end if
-                     end do
-                  end do
-               end if
-
-               call hd_get_flux_gpu(wRC, wRp, x, ixI^L, ixC^L, idims, fRC)
-               
-               if (any(fRC(ixC^S,1) .ne. fRC(ixC^S,1)) ) then
-                  print *, 'NaN found in fRC', idims
-                  do idbg2=ixCmin2,ixCmax2
-                     do idbg1=ixCmin1,ixCmax1
-                        if (fRC(idbg1,idbg2,1) .ne. fRC(idbg1,idbg2,1)) then
-                           write(*,*), 'FRC', igrid, idbg1, idbg2, fRC(idbg1,idbg2,1)
-                        end if
-                     end do
-                  end do
-               end if
-               
-               if (any(wRp(ixCR^S,p_) .le. 0.0d0) .or. any(wLp(ixCR^S,p_) .le. 0.0d0)) then
-                  print *, igrid, 'negative pressure found B'
-                  do idbg2=ixCRmin2,ixCRmax2
-                     do idbg1=ixCRmin1,ixCRmax1
-                        if (wRp(idbg1,idbg2,p_) .le. 0.0d0 .or. wLp(idbg1,idbg2,p_) .le. 0.0d0) then
-                           write(*,*), 'pR', igrid, idbg1, idbg2, wRp(idbg1,idbg2,p_)
-                           write(*,*), 'pL', igrid, idbg1, idbg2, wLp(idbg1,idbg2,p_)
-                        end if
-                     end do
-                  end do
-               end if
-               
-               call hd_get_cbounds_gpu(wLC, wRC, wLp, wRp, x, ixI^L, ixC^L, idims, Hspeed, cmaxC, cminC)
-
-               if (any(cmaxC(ixC^S,1) .ne. cmaxC(ixC^S,1)) ) then
-                  print *, 'NaN found in cmaxC', idims
-                  do idbg2=ixCmin2,ixCmax2
-                     do idbg1=ixCmin1,ixCmax1
-                        if (cmaxC(idbg1,idbg2,1) .ne. cmaxC(idbg1,idbg2,1)) then
-                           write(*,*), 'cmax', igrid, idbg1, idbg2, cmaxC(idbg1,idbg2,1)
-                        end if
-                     end do
-                  end do
-               end if
-               
-               if (any(cminC(ixC^S,1) .ne. cminC(ixC^S,1)) ) then
-                  print *, 'NaN found in cminC', idims
-                  do idbg2=ixCmin2,ixCmax2
-                     do idbg1=ixCmin1,ixCmax1
-                        if (cminC(idbg1,idbg2,1) .ne. cminC(idbg1,idbg2,1)) then
-                           write(*,*), 'cmin', igrid, idbg1, idbg2, cminC(idbg1,idbg2,1)
-                        end if
-                     end do
-                  end do
-               end if
-               
-               ! use approximate Riemann solver to get flux at interfaces
-               do ii = 1, number_species
-                  do iw = start_indices(ii), stop_indices(ii)
-                     {do ix^DB = ixCmin^DB, ixCmax^DB\}
-                     if (cminC(ix^D, ii) >= zero) then
-                        fC(ix^D, iw, idims) = fLC(ix^D, iw)
-                     else if (cmaxC(ix^D, ii) <= zero) then
-                        fC(ix^D, iw, idims) = fRC(ix^D, iw)
-                     else
-                        ! Add hll dissipation to the flux
-                        fC(ix^D, iw, idims) = (cmaxC(ix^D, ii)*fLC(ix^D, iw) - cminC(ix^D, ii)*fRC(ix^D, iw) &
-                                               + cminC(ix^D, ii)*cmaxC(ix^D, ii)*(wRC(ix^D, iw) - wLC(ix^D, iw))) &
-                                              /(cmaxC(ix^D, ii) - cminC(ix^D, ii))
-                     end if
-                     {end do\}
-                  end do
-               end do
-
-               
-            if (any(fC(ixC^S,1,idims) .ne. fc(ixC^S,1,idims)) ) then
-               print *, 'NaN found in fC A', idims
-               do idbg2=ixCmin2,ixCmax2
-                  do idbg1=ixCmin1,ixCmax1
-                     if (fC(idbg1,idbg2,1,idims) .ne. fC(idbg1,idbg2,1,idims)) then
-                        write(*,*), 'F', igrid, idbg1, idbg2, fC(idbg1,idbg2,1,idims)
-                        write(*,*), 'A', igrid, idbg1, idbg2, cmaxC(idbg1,idbg2,1)
-                        write(*,*), 'I', igrid, idbg1, idbg2, cminC(idbg1,idbg2,1)
-                     end if
-                  end do
-               end do
-            end if
-               
-            end do ! Next idims
-
-            b0i = 0
-            dxinv = -qdt/dxs
-            do idims = idims^LIM
-               hxO^L=ixO^L-kr(idims,^D); 
-               fC(ixI^S, 1:nwflux, idims)=dxinv(idims)*fC(ixI^S, 1:nwflux, idims)
-
-               
-            ! if (any(fC(ixI^S,1,idims) .ne. fc(ixI^S,1,idims)) ) then
-            !    print *, 'NaN found in fC B', idims
-            !    do idbg2=ixImin2,ixImax2
-            !       do idbg1=ixImin1,ixImax1
-            !          print *, igrid, idbg1, idbg2, fC(idbg1,idbg2,1,idims)
-            !       end do
-            !    end do
-            ! end if
-               
-               !            end if
-               bg(ib)%w(ixO^S, iwstart:nwflux, igrid) = bg(ib)%w(ixO^S, iwstart:nwflux, igrid) + &
-                                             (fC(ixO^S, iwstart:nwflux, idims) - fC(hxO^S, iwstart:nwflux, idims))
-
-            end do ! Next idims
-
-            print *, 'fvolume_all B:', igrid, maxval(bg(ib)%w(:,:,1,igrid)), maxval(bg(ia)%w(:,:,1,igrid))
-            if (any(bg(ib)%w(:,:,1,igrid) .ne. bg(ib)%w(:,:,1,igrid)) ) then
-               print *, 'NaN found in wnew B'
-               do idbg2=ixImin2,ixImax2
-                  do idbg1=ixImin1,ixImax1
-                     print *, idbg1, idbg2, bg(ib)%w(idbg1,idbg2,1,igrid)
-                  end do
-               end do
-            end if
-
-!         end associate
       end do   ! igrid
 
-   end subroutine finite_volume_all
+    end subroutine finite_volume_all
 
-   !> Determine the upwinded wLC(ixL) and wRC(ixR) from w.
-   !> the wCT is only used when PPM is exploited.
+    !> Determine the upwinded wLC(ixL) and wRC(ixR) from w.
+    !> the wCT is only used when PPM is exploited.
    subroutine reconstruct_LR_gpu(ixI^L, ixL^L, ixR^L, idims, w, wLC, wRC, wLp, wRp, x, dxdim, igrid)
       use mod_physics
       use mod_global_parameters

--- a/src/mod_functions_connectivity.t
+++ b/src/mod_functions_connectivity.t
@@ -49,6 +49,7 @@ module mod_functions_connectivity
     end do
   
     igridstail=iigrid
+    !$acc update device(igrids, igridstail)
   
   end subroutine getigrids
   

--- a/src/mod_ghostcells_update.t
+++ b/src/mod_ghostcells_update.t
@@ -891,62 +891,17 @@ contains
             ixS^L=ixS_srl_^L(iib^D,i^D);
             ixR^L=ixR_srl_^L(iib^D,n_i^D);
 
-            !opedit: not yet working somehow, doing it on host for now... :
-            ! if (igrid == ineighbor) then
-            !    !$acc enter data copyin(psb(igrid), psb(igrid)%w)
-            ! else
-            !    !$acc enter data copyin(psb(igrid), psb(ineighbor), psb(igrid)%w, psb(ineighbor)%w)
-            ! end if
-            ! !$acc kernels present(psb(igrid), psb(ineighbor), psb(igrid)%w, psb(ineighbor)%w)
-            ! psb(ineighbor)%w(ixR^S,nwhead:nwtail)=&
-            !      psb(igrid)%w(ixS^S,nwhead:nwtail)
-            ! !$acc end kernels
-            ! if (igrid == ineighbor) then
-            !    !$acc exit data copyout(psb(ineighbor), psb(ineighbor)%w)
-            ! else
-            !    !$acc exit data delete(psb(igrid), psb(ineighbor), psb(igrid)%w) copyout(psb(ineighbor)%w)
-            ! end if
-
-            ! if (igrid == ineighbor) then
-            !    !$acc enter data copyin(psb(igrid)%w)
-            ! else
-            !    !$acc enter data copyin(psb(igrid)%w, psb(ineighbor)%w)
-            ! end if
-            ! !$acc kernels present(psb(igrid)%w, psb(ineighbor)%w)
-            ! psb(ineighbor)%w(ixR^S,nwhead:nwtail)=&
-            !      psb(igrid)%w(ixS^S,nwhead:nwtail)
-            ! !$acc end kernels
-            ! if (igrid == ineighbor) then
-            !    !$acc exit data copyout(psb(ineighbor)%w)
-            ! else
-            !    !$acc exit data delete(psb(igrid)%w) copyout(psb(ineighbor)%w)
-            ! end if
-
-            !opedit: this seems to be working, keeping the other variants (also working) commented just in case:
             istage = psb(ineighbor)%istep
-            print *, 'istage:', istage, ineighbor, igrid
+            ! Copyin since this is also called on the host.
+            ! That should not do anything if the data is already on device.
             !$acc enter data copyin(bg(istage)%w)
-            
-            !$acc update host(bg(istage)%w)
-            print *, 'pre GC, istage:', istage
-            print *, 'ineighbor', ineighbor, bg(istage)%w(ixR^S,1,ineighbor)
-            print *, 'igrid', igrid, bg(istage)%w(ixS^S,1,igrid)
-            
             !$acc kernels present(bg(istage)%w)
             bg(istage)%w(ixR^S,nwhead:nwtail,ineighbor)=&
                  bg(istage)%w(ixS^S,nwhead:nwtail,igrid)
-            
-!            psb(ineighbor)%w(ixR^S,nwhead:nwtail)=&
-!                 psb(igrid)%w(ixS^S,nwhead:nwtail)
             !$acc end kernels
-
-            !$acc update host(bg(istage)%w)
-            print *, 'post GC, istage:', istage, bg(istage)%w(ixR^S,1,ineighbor)
-
+            ! See above, should not do anything if data was already on device /I think/
             !$acc exit data copyout(bg(istage)%w)
 
-
-            
             if(stagger_grid) then
               do idir=1,ndim
                 ixS^L=ixS_srl_stg_^L(idir,i^D);

--- a/src/mod_ghostcells_update.t
+++ b/src/mod_ghostcells_update.t
@@ -891,17 +891,28 @@ contains
             ixS^L=ixS_srl_^L(iib^D,i^D);
             ixR^L=ixR_srl_^L(iib^D,n_i^D);
 
-            istage = psb(ineighbor)%istep
-            ! Copyin since this is also called on the host.
-            ! That should not do anything if the data is already on device.
-            !$acc enter data copyin(bg(istage)%w)
-            !$acc kernels present(bg(istage)%w)
-            bg(istage)%w(ixR^S,nwhead:nwtail,ineighbor)=&
-                 bg(istage)%w(ixS^S,nwhead:nwtail,igrid)
-            !$acc end kernels
-            ! See above, should not do anything if data was already on device /I think/
-            !$acc exit data copyout(bg(istage)%w)
+            ! Debugging corner issues. Does this cause it?
+            ! istage = psb(ineighbor)%istep
+            ! ! Copyin since this is also called on the host.
+            ! ! That should not do anything if the data is already on device.
+            ! !$acc enter data copyin(bg(istage)%w)
+            ! !$acc kernels present(bg(istage)%w)
+            ! bg(istage)%w(ixR^S,nwhead:nwtail,ineighbor)=&
+            !      bg(istage)%w(ixS^S,nwhead:nwtail,igrid)
+            ! !$acc end kernels
+            ! ! See above, should not do anything if data was already on device /I think/
+            ! !$acc exit data copyout(bg(istage)%w)
 
+            !opedit: this seems to be working, keeping the other variants (also working) commented just in case:
+            !$acc enter data copyin(psb(igrid)%w, psb(ineighbor)%w)
+            !$acc kernels present(psb(igrid)%w, psb(ineighbor)%w)
+            psb(ineighbor)%w(ixR^S,nwhead:nwtail)=&
+                 psb(igrid)%w(ixS^S,nwhead:nwtail)
+            !$acc end kernels
+            !$acc exit data delete(psb(igrid)%w) copyout(psb(ineighbor)%w)
+
+
+            
             if(stagger_grid) then
               do idir=1,ndim
                 ixS^L=ixS_srl_stg_^L(idir,i^D);

--- a/src/mod_physicaldata.t
+++ b/src/mod_physicaldata.t
@@ -24,9 +24,9 @@ module mod_physicaldata
      !> If it face a physical boundary
      logical, dimension(:), pointer :: is_physical_boundary(:) =>Null()
      !> Variables, normally cell center conservative values
-     double precision, dimension(:^D&,:), pointer, contiguous :: w => Null()
+     double precision, dimension(:^D&,:), pointer :: w => Null()
      !> Variables, cell face values
-     double precision, dimension(:^D&,:), pointer, contiguous :: ws => Null()
+     double precision, dimension(:^D&,:), pointer :: ws => Null()
      !> Variables, cell edge values
      double precision, dimension(:^D&,:), allocatable :: we
      !> Variables, cell corner values

--- a/tests/hd/AGILE_baseline/amrvac.par
+++ b/tests/hd/AGILE_baseline/amrvac.par
@@ -9,12 +9,12 @@
  &savelist
    itsave(1,1)      = 0
    itsave(1,2)      = 0
-   ditsave_log      = 1
-   ditsave_dat      = 1
+   ditsave_log      = 10
+   dtsave_dat       = 1
  /
 
  &stoplist
-   it_max = 10
+   it_max = 10000
  /
 
  &methodlist
@@ -31,12 +31,12 @@
  /
 
  &meshlist
-   max_blocks         = 4
+   max_blocks         = 1024
    refine_max_level   = 1
-   block_nx1          = 64
-   block_nx2          = 64
-   domain_nx1         = 128
-   domain_nx2         = 128
+   block_nx1          = 16
+   block_nx2          = 16
+   domain_nx1         = 512
+   domain_nx2         = 512
    xprobmin1       = 0.0d0
    xprobmax1       = 1.0d0
    xprobmin2       = 0.0d0

--- a/tests/hd/AGILE_baseline/amrvac.par
+++ b/tests/hd/AGILE_baseline/amrvac.par
@@ -35,8 +35,8 @@
    refine_max_level   = 1
    block_nx1          = 16
    block_nx2          = 16
-   domain_nx1         = 512
-   domain_nx2         = 512
+   domain_nx1         = 128
+   domain_nx2         = 128
    xprobmin1       = 0.0d0
    xprobmax1       = 1.0d0
    xprobmin2       = 0.0d0

--- a/tests/hd/AGILE_baseline/amrvac.par
+++ b/tests/hd/AGILE_baseline/amrvac.par
@@ -8,12 +8,13 @@
 
  &savelist
    itsave(1,1)      = 0
-   ditsave_log      = 10
-   ditsave_dat      = 10
+   itsave(1,2)      = 0
+   ditsave_log      = 1
+   ditsave_dat      = 1
  /
 
  &stoplist
-   it_max = 100
+   it_max = 10
  /
 
  &methodlist
@@ -30,10 +31,10 @@
  /
 
  &meshlist
-   max_blocks         = 1
+   max_blocks         = 4
    refine_max_level   = 1
-   block_nx1          = 128
-   block_nx2          = 128
+   block_nx1          = 64
+   block_nx2          = 64
    domain_nx1         = 128
    domain_nx2         = 128
    xprobmin1       = 0.0d0

--- a/tests/hd/AGILE_baseline/amrvac.par
+++ b/tests/hd/AGILE_baseline/amrvac.par
@@ -2,7 +2,7 @@
  &filelist
    base_filename    = 'kh_2d'
    autoconvert      = T
-   convert_type     = 'vtuBmpi'
+   convert_type     = 'vtuBCCmpi'
    saveprim         = T
  /
 

--- a/tests/hd/AGILE_baseline/amrvac_test.par
+++ b/tests/hd/AGILE_baseline/amrvac_test.par
@@ -3,7 +3,7 @@
    base_filename    = 'khi'
    typefilelog      = 'regression_test'
    autoconvert      = T
-   convert_type     = 'vtuBmpi'
+   convert_type     = 'vtuBCCmpi'
    saveprim         = T
  /
 


### PR DESCRIPTION
see also other commit logs. 
There were actually two issues which I would label as compiler bugs:

1. for some mystery reason, at initialization of the fluid variables in the second block, it would change the first block too.  This is an issue with the ps%w pointer to the block grid bg%w.  Very odd since this mixup already happened on the host.  
fix: remove the contiguous attribute from declaration of ps%w (weird since it the array section it points to is contiguous, but perhaps pointing to sections of arrays is already disallowed if declared contiguous).  
2. too much indirection, and after associate to the section from the (passed in by reference) bg%w array, data in this array seemed shifted somehow.  Concretely, I had negative pressures in that array (perhaps interpreting velocity as pressure).  This led to the NaNs we were staring at since cbounds takes a sqrt of a negative number then.  
fix: just recover the index of the bg(.) structures which were passed to mod_finite_volume_all and work directly with bg(ia)%w. 

Running it reveals issues with the grid corners showing up in the snapshots (also I did not do the autotest).  Also its still slow (100x slower that acc-exp).  

![image](https://github.com/user-attachments/assets/c54a18fb-e897-4c9a-a179-8fe8667cae90)

One recurring issue is that with big blocks we fail at automatically allocating space on the GPU for all those temporary arrays in the kernel (error message FORTRAN automatic arrays failed or so).  

I can run it on my GPU with these domain decomposition settings:

```
   max_blocks         = 1024
   refine_max_level   = 1
   block_nx1          = 16
   block_nx2          = 16
   domain_nx1         = 512
   domain_nx2         = 512
```

smaller domains also run.  Going bigger or bigger blocks leads to the automatic allocation issue.  

Ok. On to the grid corner issue, sigh... 

