### PR TITLE
fixing the integer conversion warning

### DIFF
--- a/src/hd/mod_hd_templates.fpp
+++ b/src/hd/mod_hd_templates.fpp
@@ -153,7 +153,7 @@
     integer                :: idim
     real(dp)               :: field
 
-    dtnew = huge(1_dp)
+    dtnew = huge(1.0d0)
     
 #:if defined('GRAVITY')
     do idim = 1, ndim


### PR DESCRIPTION
it seems not to like custom kind descriptors in the huge intrinsic function.