### PR TITLE
Fix KH3D compilation

### DIFF
--- a/tests-v2/benchmark_KH3D/amrvac.par
+++ b/tests-v2/benchmark_KH3D/amrvac.par
@@ -24,7 +24,7 @@
    flux_scheme     = 20*'tvdlf'
    limiter         = 20*'vanleer'
    small_values_method = 'ignore'
- !  phys                = 'hd'
+   phys                = 'hd'
  /
 
  &boundlist


### PR DESCRIPTION
I tried compiling the master branch with the KH3D case but it failed because `phys` wasn't set in amrvac.par. The option was there, just commented out. Now it's there properly and the compiler is happy.