### PR TITLE
Move inter-rank ghostcell exchange to the GPU

### DIFF
--- a/arch/nvidia.mk
+++ b/arch/nvidia.mk
@@ -3,6 +3,13 @@ arch := nvidia
 compile = mpif90
 f90_flags += -cpp -Mfree
 
+ifdef NVTX
+$(info Enabling NVTX)
+enabled += NVTX
+f90_flags += -DNVTX
+link_flags += -lnvToolsExt
+endif
+
 ifdef OPENMP
 $(info Enabling OpenMP)
 enabled += OPENMP
@@ -28,4 +35,4 @@ else
 f90_flags += -O3 -fast
 endif
 
-link_flags += $(f90_flags) -lnvToolsExt
+link_flags += $(f90_flags)

--- a/arch/nvidia.mk
+++ b/arch/nvidia.mk
@@ -13,6 +13,11 @@ ifdef OPENACC
 $(info Enabling OpenACC)
 f90_flags += -Wall -acc=gpu -Minfo=all -Mvect=levels:5 -Minline
 enabled += OPENACC
+ifdef NOGPUDIRECT
+$(info Disabling direct GPU-GPU copies)
+f90_flags += -DNOGPUDIRECT
+enabled += NOGPUDIRECT
+endif
 endif
 
 ifdef DEBUG
@@ -24,4 +29,3 @@ f90_flags += -O3 -fast
 endif
 
 link_flags += $(f90_flags) -lnvToolsExt
-

--- a/make/25-store-flags.mk
+++ b/make/25-store-flags.mk
@@ -1,6 +1,6 @@
 # When make is called with command-line overrides, we want to store
 # those for provenance. Also those overrides become defaults for
-# recurrent invocations to make. Currently this is done for 
+# recurrent invocations to make. Currently this is done for
 # DEBUG and OPENMP flags. In general, any flag that doesn't modify
 # the output of AMRVAC (so no physics, or anything meaningful),
 # but change the efficiency or amount of analysis done should go here:
@@ -21,8 +21,10 @@ endif
 ifdef OPENACC
 	@echo "OPENACC ?= $(OPENACC)" >> $@
 endif
+ifdef NOGPUDIRECT
+	@echo "NOGPUDIRECT ?= $(NOGPUDIRECT)" >> $@
+endif
 
 $(build_dir)/config.mk: config.mk
 	@mkdir -p $(@D)
 	@cp $< $@
-

--- a/make/25-store-flags.mk
+++ b/make/25-store-flags.mk
@@ -24,6 +24,9 @@ endif
 ifdef NOGPUDIRECT
 	@echo "NOGPUDIRECT ?= $(NOGPUDIRECT)" >> $@
 endif
+ifdef NVTX
+	@echo "NVTX ?= $(NVTX)" >> $@
+endif
 
 $(build_dir)/config.mk: config.mk
 	@mkdir -p $(@D)

--- a/make/30-fypp.mk
+++ b/make/30-fypp.mk
@@ -1,7 +1,3 @@
-ifdef OPENMP
-fypp_flags += -DOPENACC
-endif
-
 ifdef DEBUG
 fypp_flags += -DDEBUG
 endif
@@ -30,4 +26,3 @@ $(patsubst %.fpp, $(build_dir)/f90/%.f90, $(notdir $(1))): $(1)
 endef
 
 $(foreach f, $(source_files), $(eval $(call fypp_rule, $(f))))
-

--- a/make/35-dependencies.mk
+++ b/make/35-dependencies.mk
@@ -9,7 +9,7 @@ endif
 ifdef CONFIG_READ
 $(build_dir)/dependencies.mk: $(f90_files) $(build_dir)/f90/amrvac.h | $(build_dir)
 	@echo "Regenerating depencies"
-	@fortdepend -f $(f90_files) -i mpi -b $(build_dir)/obj -w -o $@
+	@fortdepend -f $(f90_files) -i mpi openacc -b $(build_dir)/obj -w -o $@
 
 # Precompiling and dependency tracking is not needed if we're cleaning.
 ifndef disable_precompile

--- a/src/amrvac.fpp
+++ b/src/amrvac.fpp
@@ -2,210 +2,244 @@
 !> \f$\vec{u}_t + \nabla_x \cdot \vec{f}(\vec{u}) = \vec{s}\f$
 !> using adaptive mesh refinement.
 program amrvac
-
-
-  use mod_global_parameters
-  use mod_input_output
-  use mod_usr_methods
-  use mod_ghostcells_update
-  use mod_usr
-  use mod_initialize
-  use mod_initialize_amr, only: initlevelone, modify_IC
-
-  use mod_initialize_amr, only: improve_initial_condition
-
-  use mod_selectgrids, only: selectgrids
-  use mod_particles
-  use mod_fix_conserve
-  use mod_advance, only: process
-  use mod_multigrid_coupling
-  use mod_convert, only: init_convert
-
-  use mod_physics
-  use mod_amr_grid, only: resettree, settree, resettree_convert
-!FIXME:
-!  use mod_trac, only: initialize_trac_after_settree
-  use mod_convert_files, only: generate_plotfile
-  use mod_comm_lib, only: comm_start, comm_finalize,mpistop
-
-
-  double precision :: time0, time_in
-  logical,save     :: part_file_exists=.false.
-
-
-  call comm_start()
-
-  time0 = MPI_WTIME()
-  time_advance = .false.
-  time_bc      = zero
-
-  ! read command line arguments first
-  call read_arguments()
-
-  ! the user_init routine should load a physics module
-  call usr_init()
-
-  call initialize_amrvac()
-
-  if (restart_from_file /= undefined) then
-  !AGILE: not yet implemented, data movement needs to happen here
+    ! Initialize MPI
+    call MPI_INIT(MPI_STATUS_IGNORE)
+   ! The OpenACC device must be set before any data is initialized on the GPU
 #ifdef _OPENACC
-     call mpistop("restart or convert on GPU not yet implemented")
+   call set_openacc_device()
 #endif
-     ! restart from previous file or dat file conversion
-     ! get input data from previous AMRVAC run
+   call main()
 
-     ! read in dat file
-     call read_snapshot()
+contains
 
-     ! rewrite it=0 snapshot when restart from it=0 state
-     if(it==0.and.itsave(1,2)==0) snapshotnext=snapshotnext-1
+#ifdef _OPENACC
+  subroutine set_openacc_device
+    use mpi
+    use openacc
+    integer :: local_rank, comm_shared, my_device, num_devices
+    integer(acc_device_kind) :: dev_type
 
-     if (reset_time) then
-       ! reset it and global time to original value
-       it           = it_init
-       global_time  = time_init
-       ! reset snapshot number
-       snapshotnext=0
-     end if
+    call MPI_COMM_SPLIT_TYPE(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, comm_shared, MPI_STATUS_IGNORE)
+    call MPI_COMM_RANK(comm_shared, local_rank, MPI_STATUS_IGNORE)
 
-     if (reset_it) then
-       ! reset it to original value
-       it           = it_init
-     end if
+    dev_type = ACC_DEVICE_DEFAULT
+    num_devices = acc_get_num_devices(dev_type)
 
-     ! modify initial condition
-     if (firstprocess) then
-       ! update ghost cells for all need-boundary variables before modification
+    if (num_devices < 1) error stop "No devices available on host"
+
+    my_device = mod(local_rank, num_devices)
+    call acc_set_device_num(my_device, dev_type)
+
+  end subroutine set_openacc_device
+#endif
+
+  subroutine main
+    use mod_global_parameters
+    use mod_input_output
+    use mod_usr_methods
+    use mod_ghostcells_update
+    use mod_usr
+    use mod_initialize
+    use mod_initialize_amr, only: initlevelone, modify_IC
+
+    use mod_initialize_amr, only: improve_initial_condition
+
+    use mod_selectgrids, only: selectgrids
+    use mod_particles
+    use mod_fix_conserve
+    use mod_advance, only: process
+    use mod_multigrid_coupling
+    use mod_convert, only: init_convert
+
+    use mod_physics
+    use mod_amr_grid, only: resettree, settree, resettree_convert
+  !FIXME:
+  !  use mod_trac, only: initialize_trac_after_settree
+    use mod_convert_files, only: generate_plotfile
+    use mod_comm_lib, only: comm_start, comm_finalize,mpistop
+
+
+    double precision :: time0, time_in
+    logical,save     :: part_file_exists=.false.
+
+
+    call comm_start()
+
+    time0 = MPI_WTIME()
+    time_advance = .false.
+    time_bc      = zero
+
+    ! read command line arguments first
+    call read_arguments()
+
+    ! the user_init routine should load a physics module
+    call usr_init()
+
+    call initialize_amrvac()
+
+    if (restart_from_file /= undefined) then
+    !AGILE: not yet implemented, data movement needs to happen here
+  #ifdef _OPENACC
+       call mpistop("restart or convert on GPU not yet implemented")
+  #endif
+       ! restart from previous file or dat file conversion
+       ! get input data from previous AMRVAC run
+
+       ! read in dat file
+       call read_snapshot()
+
+       ! rewrite it=0 snapshot when restart from it=0 state
+       if(it==0.and.itsave(1,2)==0) snapshotnext=snapshotnext-1
+
+       if (reset_time) then
+         ! reset it and global time to original value
+         it           = it_init
+         global_time  = time_init
+         ! reset snapshot number
+         snapshotnext=0
+       end if
+
+       if (reset_it) then
+         ! reset it to original value
+         it           = it_init
+       end if
+
+       ! modify initial condition
+       if (firstprocess) then
+         ! update ghost cells for all need-boundary variables before modification
+         call getbc(global_time,0.d0,ps,1,nwflux+nwaux)
+         call modify_IC
+       end if
+
+       ! select active grids
+       call selectgrids
+
+       ! update ghost cells for all need-boundary variables
        call getbc(global_time,0.d0,ps,1,nwflux+nwaux)
-       call modify_IC
-     end if
 
-     ! select active grids
-     call selectgrids
+       ! reset AMR grid
+       if (reset_grid) then
+         call settree
+       else
+         ! set up boundary flux conservation arrays
+         if (levmax>levmin) call allocateBflux
+       end if
 
-     ! update ghost cells for all need-boundary variables
-     call getbc(global_time,0.d0,ps,1,nwflux+nwaux)
-
-     ! reset AMR grid
-     if (reset_grid) then
-       call settree
-     else
-       ! set up boundary flux conservation arrays
-       if (levmax>levmin) call allocateBflux
-     end if
-
-     ! all blocks refined to the same level for output
-     if(convert .and. level_io>0 .or. level_io_min.ne.1 .or. &
-        level_io_max.ne.nlevelshi) call resettree_convert
+       ! all blocks refined to the same level for output
+       if(convert .and. level_io>0 .or. level_io_min.ne.1 .or. &
+          level_io_max.ne.nlevelshi) call resettree_convert
 
 
-     ! improve initial condition after restart and modification
-     if(firstprocess) call improve_initial_condition()
+       ! improve initial condition after restart and modification
+       if(firstprocess) call improve_initial_condition()
 
 
-     if (use_multigrid) call mg_setup_multigrid()
+       if (use_multigrid) call mg_setup_multigrid()
 
-     if(use_particles) then
-       call read_particles_snapshot(part_file_exists)
-       call init_gridvars()
-       if (.not. part_file_exists) call particles_create()
+       if(use_particles) then
+         call read_particles_snapshot(part_file_exists)
+         call init_gridvars()
+         if (.not. part_file_exists) call particles_create()
+         if(convert) then
+           call handle_particles()
+           call finish_gridvars()
+           call time_spent_on_particles()
+           call comm_finalize
+           stop
+         end if
+       end if
+
        if(convert) then
-         call handle_particles()
-         call finish_gridvars()
-         call time_spent_on_particles()
+         if (npe/=1.and.(.not.(index(convert_type,&
+            'mpi')>=1)) .and. convert_type .ne. 'user')  call &
+            mpistop("non-mpi conversion only uses 1 cpu")
+         if(mype==0.and.level_io>0) write(unitterm,&
+            *)'reset tree to fixed level=',level_io
+
+         ! Optionally call a user method that can modify the grid variables
+         ! before saving the converted data
+         if (associated(usr_process_grid) .or. associated(usr_process_global)) &
+            then
+            call process(it,global_time)
+         end if
+         !here requires -1 snapshot
+         if (autoconvert .or. snapshotnext>0) snapshotnext = snapshotnext - 1
+
+         if(associated(phys_special_advance)) then
+           ! e.g. calculate MF velocity from magnetic field
+           call phys_special_advance(global_time,ps)
+         end if
+
+         call generate_plotfile
          call comm_finalize
          stop
        end if
-     end if
 
-     if(convert) then
-       if (npe/=1.and.(.not.(index(convert_type,&
-          'mpi')>=1)) .and. convert_type .ne. 'user')  call &
-          mpistop("non-mpi conversion only uses 1 cpu")
-       if(mype==0.and.level_io>0) write(unitterm,&
-          *)'reset tree to fixed level=',level_io
+    else
 
-       ! Optionally call a user method that can modify the grid variables
-       ! before saving the converted data
-       if (associated(usr_process_grid) .or. associated(usr_process_global)) &
-          then
-          call process(it,global_time)
+       ! form and initialize all grids at level one
+       call initlevelone
+
+       ! set up and initialize finer level grids, if needed
+       call settree
+
+       if (use_multigrid) call mg_setup_multigrid()
+
+
+       ! improve initial condition
+       call improve_initial_condition()
+
+
+       ! select active grids
+       call selectgrids
+
+       if (use_particles) then
+         call init_gridvars()
+         call particles_create()
        end if
-       !here requires -1 snapshot
-       if (autoconvert .or. snapshotnext>0) snapshotnext = snapshotnext - 1
 
-       if(associated(phys_special_advance)) then
-         ! e.g. calculate MF velocity from magnetic field
-         call phys_special_advance(global_time,ps)
-       end if
+    end if
 
-       call generate_plotfile
-       call comm_finalize
-       stop
-     end if
+  !FIXME:
+    ! initialize something base on tree information
+  !  call initialize_trac_after_settree
 
-  else
+    if (mype==0) then
+       print*,'-------------------------------------------------------------------------------'
+       write(*,'(a,f17.3,a)')' Startup phase took : ',MPI_WTIME()-time0,' sec'
+       print*,'-------------------------------------------------------------------------------'
+    end if
 
-     ! form and initialize all grids at level one
-     call initlevelone
+    ! an interface to allow user to do special things before the main loop
+    if (associated(usr_before_main_loop)) call usr_before_main_loop()
 
-     ! set up and initialize finer level grids, if needed
-     call settree
+    ! do time integration of all grids on all levels
+    call timeintegration()
 
-     if (use_multigrid) call mg_setup_multigrid()
+    if (mype==0) then
+       print*,'-------------------------------------------------------------------------------'
+       write(*,'(a,f17.3,a)')' Finished AMRVAC in : ',MPI_WTIME()-time0,' sec'
+       print*,'-------------------------------------------------------------------------------'
+    end if
 
+    call comm_finalize
 
-     ! improve initial condition
-     call improve_initial_condition()
-
-
-     ! select active grids
-     call selectgrids
-
-     if (use_particles) then
-       call init_gridvars()
-       call particles_create()
-     end if
-
-  end if
-
-!FIXME:
-  ! initialize something base on tree information
-!  call initialize_trac_after_settree
-
-  if (mype==0) then
-     print*,'-------------------------------------------------------------------------------'
-     write(*,'(a,f17.3,a)')' Startup phase took : ',MPI_WTIME()-time0,' sec'
-     print*,'-------------------------------------------------------------------------------'
-  end if
-
-  ! an interface to allow user to do special things before the main loop
-  if (associated(usr_before_main_loop)) call usr_before_main_loop()
-
-  ! do time integration of all grids on all levels
-  call timeintegration()
-
-  if (mype==0) then
-     print*,'-------------------------------------------------------------------------------'
-     write(*,'(a,f17.3,a)')' Finished AMRVAC in : ',MPI_WTIME()-time0,' sec'
-     print*,'-------------------------------------------------------------------------------'
-  end if
-
-  call comm_finalize
-
-contains
+  end subroutine main
 
   subroutine timeintegration()
     use mod_nvtx
     use mod_timing
     use mod_advance, only: advance, process, process_advanced
+    use mod_amr_grid, only: resettree, settree, resettree_convert
     use mod_forest, only: nleafs_active
     use mod_global_parameters
     use mod_input_output, only: saveamrfile
     use mod_input_output_helper, only: save_now
     use mod_ghostcells_update
+    use mod_multigrid_coupling
     use mod_dt, only: setdt
+    use mod_particles
+    use mod_usr_methods
 
 
     integer :: level, ifile, fixcount, ncells_block, igrid, iigrid, itimelevel

--- a/src/amrvac.fpp
+++ b/src/amrvac.fpp
@@ -3,6 +3,7 @@
 !> using adaptive mesh refinement.
 program amrvac
 
+
   use mod_global_parameters
   use mod_input_output
   use mod_usr_methods
@@ -10,9 +11,9 @@ program amrvac
   use mod_usr
   use mod_initialize
   use mod_initialize_amr, only: initlevelone, modify_IC
-  
+
   use mod_initialize_amr, only: improve_initial_condition
- 
+
   use mod_selectgrids, only: selectgrids
   use mod_particles
   use mod_fix_conserve
@@ -22,7 +23,7 @@ program amrvac
 
   use mod_physics
   use mod_amr_grid, only: resettree, settree, resettree_convert
-!FIXME:  
+!FIXME:
 !  use mod_trac, only: initialize_trac_after_settree
   use mod_convert_files, only: generate_plotfile
   use mod_comm_lib, only: comm_start, comm_finalize,mpistop
@@ -46,7 +47,7 @@ program amrvac
 
   call initialize_amrvac()
 
-  if (restart_from_file /= undefined) then 
+  if (restart_from_file /= undefined) then
   !AGILE: not yet implemented, data movement needs to happen here
 #ifdef _OPENACC
      call mpistop("restart or convert on GPU not yet implemented")
@@ -57,7 +58,7 @@ program amrvac
      ! read in dat file
      call read_snapshot()
 
-     ! rewrite it=0 snapshot when restart from it=0 state 
+     ! rewrite it=0 snapshot when restart from it=0 state
      if(it==0.and.itsave(1,2)==0) snapshotnext=snapshotnext-1
 
      if (reset_time) then
@@ -98,10 +99,10 @@ program amrvac
      if(convert .and. level_io>0 .or. level_io_min.ne.1 .or. &
         level_io_max.ne.nlevelshi) call resettree_convert
 
-     
+
      ! improve initial condition after restart and modification
      if(firstprocess) call improve_initial_condition()
-    
+
 
      if (use_multigrid) call mg_setup_multigrid()
 
@@ -154,10 +155,10 @@ program amrvac
 
      if (use_multigrid) call mg_setup_multigrid()
 
-     
+
      ! improve initial condition
      call improve_initial_condition()
-    
+
 
      ! select active grids
      call selectgrids
@@ -169,10 +170,10 @@ program amrvac
 
   end if
 
-!FIXME:  
+!FIXME:
   ! initialize something base on tree information
 !  call initialize_trac_after_settree
-  
+
   if (mype==0) then
      print*,'-------------------------------------------------------------------------------'
      write(*,'(a,f17.3,a)')' Startup phase took : ',MPI_WTIME()-time0,' sec'
@@ -423,7 +424,7 @@ contains
            timeio0 - time_in
     end if
 
-    
+
 
     if(use_particles) call time_spent_on_particles
 

--- a/src/mod_comm_lib.fpp
+++ b/src/mod_comm_lib.fpp
@@ -3,7 +3,6 @@ module mod_comm_lib
   implicit none
   private
 
-
   public :: comm_start
   public :: comm_finalize
   public :: init_comm_types
@@ -16,25 +15,22 @@ contains
   !> Initialize the MPI environment
   subroutine comm_start
     use mod_global_parameters
-  
+
     integer(kind=MPI_ADDRESS_KIND) :: lb
     integer(kind=MPI_ADDRESS_KIND) :: sizes
-  
-    ! Initialize MPI
-    call MPI_INIT(ierrmpi)
-  
+
     ! Each process stores its rank, which ranges from 0 to N-1, where N is the
     ! number of processes.
     call MPI_COMM_RANK(MPI_COMM_WORLD,mype,ierrmpi)
-  
+
     ! Store the number of processes
     call MPI_COMM_SIZE(MPI_COMM_WORLD,npe,ierrmpi)
 
     !$acc update device(mype,npe)
-  
+
     ! Use the default communicator, which contains all the processes
     icomm = MPI_COMM_WORLD
-  
+
     ! Get size of double/integer
     call MPI_TYPE_GET_EXTENT(MPI_REAL,lb,sizes,ierrmpi)
     if (sizes /= size_real) call mpistop("Incompatible real size")
@@ -45,102 +41,29 @@ contains
     call MPI_TYPE_GET_EXTENT(MPI_LOGICAL,lb,sizes,ierrmpi)
     if (sizes /= size_logical) call mpistop("Incompatible logical size")
 
-#ifdef _OPENACC
-    call set_openacc_device
-#endif
-    
   end subroutine comm_start
-  
-#ifdef _OPENACC
-  !> Set the device to be used by OpenACC. Code based on:
-  !> https://docs.nvidia.com/hpc-sdk/compilers/openacc-mpi-tutorial/
-  !> OpenMPI provides an environment variable, but this is not portable
-  !> Taken from Jannis Teunissen foap4
-  subroutine set_openacc_device
-    use mod_global_parameters
-    use openacc
 
-    ! f4%mpisize -> npe
-    ! f4%mpirank -> mype
-    ! f4%mpicomm -> MPI_COMM_WORLD
-
-    interface
-       ! Get a unique number to identify the host
-       function gethostid() bind(C)
-         import C_int
-         integer (C_int) :: gethostid
-       end function gethostid
-    end interface
-
-    integer :: hostids(0:npe-1), local_procs(0:npe-1)
-    integer :: hostid, ierr, num_devices, my_device, rank, num_local_procs
-    integer(acc_device_kind) :: dev_type
-
-    dev_type = ACC_DEVICE_DEFAULT
-
-    ! Get the hostids to determine how many processes are on this host
-    hostid = gethostid()
-    call MPI_Allgather(hostid, 1, MPI_INTEGER, hostids, 1, MPI_INTEGER, &
-         MPI_COMM_WORLD, ierr)
-
-    ! Determine the local MPI ranks and number them, starting at zero
-    num_local_procs = 0
-    local_procs     = 0
-
-    do rank = 0, npe-1
-       if (hostid == hostids(rank)) then
-          local_procs(rank) = num_local_procs
-          num_local_procs = num_local_procs+1
-       endif
-    enddo
-
-    num_devices = acc_get_num_devices(dev_type)
-    if (num_devices < 1) error stop "No devices available on host"
-
-    if (num_devices < num_local_procs) then
-       ! Print warning only for first local process
-       if (local_procs(mype) == 0) then
-          write(*, "(A,I0,A,I0,A,I0,A)") "WARNING from ", mype, &
-               ": more local processes (", num_local_procs, &
-               ") than GPUs (", num_devices, ")"
-       endif
-
-       my_device = mod(local_procs(mype), num_devices)
-    else
-       my_device = local_procs(mype)
-    endif
-
-    call acc_set_device_num(my_device, dev_type)
-
-    ! Print some debugging info for now
-    print *, 'mype, npe, num_devices:', mype, npe, num_devices
-    print *, 'mype, my_device', mype, acc_get_device_num(dev_type)
-    print *, 'mype, num_local_procs', mype, num_local_procs
-
-  end subroutine set_openacc_device
-#endif
-  
   !> Finalize (or shutdown) the MPI environment
   subroutine comm_finalize
     use mod_global_parameters
-    
+
     call MPI_BARRIER(MPI_COMM_WORLD,ierrmpi)
     call MPI_FINALIZE(ierrmpi)
-  
+
   end subroutine comm_finalize
-  
+
   !> Create and store the MPI types that will be used for parallel communication
   subroutine init_comm_types
     use mod_global_parameters
-  
+
     integer, dimension(ndim+1) :: sizes, subsizes, start
     integer :: i1,i2,i3, ic1,ic2,ic3, nx1,nx2,nx3, nxCo1,nxCo2,nxCo3, nxG1,&
        nxG2,nxG3, idir
-  
+
     nx1=ixMhi1-ixMlo1+1;nx2=ixMhi2-ixMlo2+1;nx3=ixMhi3-ixMlo3+1;
     nxG1=ixGhi1-ixGlo1+1;nxG2=ixGhi2-ixGlo2+1;nxG3=ixGhi3-ixGlo3+1;
     nxCo1=nx1/2;nxCo2=nx2/2;nxCo3=nx3/2;
-  
+
     sizes(1)=ixGhi1;sizes(2)=ixGhi2;sizes(3)=ixGhi3;
     sizes(ndim+1)=nw
     subsizes(1)=nxG1;subsizes(2)=nxG2;subsizes(3)=nxG3;
@@ -151,7 +74,7 @@ contains
         MPI_ORDER_FORTRAN,MPI_DOUBLE_PRECISION, type_block,ierrmpi)
     call MPI_TYPE_COMMIT(type_block,ierrmpi)
     size_block=nxG1*nxG2*nxG3*nw*size_double
-  
+
     sizes(1)=ixGhi1/2+nghostcells;sizes(2)=ixGhi2/2+nghostcells
     sizes(3)=ixGhi3/2+nghostcells;
     sizes(ndim+1)=nw
@@ -162,7 +85,7 @@ contains
     call MPI_TYPE_CREATE_SUBARRAY(ndim+1,sizes,subsizes,start,&
         MPI_ORDER_FORTRAN,MPI_DOUBLE_PRECISION, type_coarse_block,ierrmpi)
     call MPI_TYPE_COMMIT(type_coarse_block,ierrmpi)
-  
+
     if(stagger_grid) then
       sizes(1)=ixGhi1+1;sizes(2)=ixGhi2+1;sizes(3)=ixGhi3+1;
       sizes(ndim+1)=nws
@@ -174,7 +97,7 @@ contains
           MPI_ORDER_FORTRAN,MPI_DOUBLE_PRECISION, type_block_io_stg,ierrmpi)
       call MPI_TYPE_COMMIT(type_block_io_stg,ierrmpi)
       size_block_io_stg=(nx1+1)*(nx2+1)*(nx3+1)*nws*size_double
-  
+
       sizes(1)=ixGhi1/2+nghostcells+1;sizes(2)=ixGhi2/2+nghostcells+1
       sizes(3)=ixGhi3/2+nghostcells+1;
       sizes(ndim+1)=nws
@@ -190,7 +113,7 @@ contains
           start(2)=ixMlo2-kr(ic2,1)*kr(idir,2)
           start(3)=ixMlo3-kr(ic3,1)*kr(idir,3);
           start(ndim+1)=idir-1
-  
+
           call MPI_TYPE_CREATE_SUBARRAY(ndim+1,sizes,subsizes,start,&
               MPI_ORDER_FORTRAN,MPI_DOUBLE_PRECISION,&
               type_coarse_block_stg(idir,ic1,ic2,ic3),ierrmpi)
@@ -200,7 +123,7 @@ contains
      end do
      end do
      end do
-  
+
       sizes(1)=ixGhi1+1;sizes(2)=ixGhi2+1;sizes(3)=ixGhi3+1;
       sizes(ndim+1)=nws
      do ic3=1,2
@@ -224,7 +147,7 @@ contains
      end do
      end do
     end if
-  
+
     sizes(1)=ixGhi1;sizes(2)=ixGhi2;sizes(3)=ixGhi3;
     sizes(ndim+1)=nw
     do ic3=1,2
@@ -242,7 +165,7 @@ contains
     end do
     end do
     end do
-  
+
     sizes(1)=ixGhi1;sizes(2)=ixGhi2;sizes(3)=ixGhi3;
     sizes(ndim+1)=nw
     subsizes(1)=nx1;subsizes(2)=nx2;subsizes(3)=nx3;
@@ -253,7 +176,7 @@ contains
         MPI_ORDER_FORTRAN,MPI_DOUBLE_PRECISION, type_block_io,ierrmpi)
     call MPI_TYPE_COMMIT(type_block_io,ierrmpi)
     size_block_io=nx1*nx2*nx3*nw*size_double
-  
+
     sizes(1)=ixMhi1-ixMlo1+1;sizes(2)=ixMhi2-ixMlo2+1
     sizes(3)=ixMhi3-ixMlo3+1;
     sizes(ndim+1)=3
@@ -264,7 +187,7 @@ contains
     call MPI_TYPE_CREATE_SUBARRAY(ndim+1,sizes,subsizes,start,&
         MPI_ORDER_FORTRAN,MPI_DOUBLE_PRECISION, type_block_xcc_io,ierrmpi)
     call MPI_TYPE_COMMIT(type_block_xcc_io,ierrmpi)
-  
+
     sizes(1)=ixMhi1-ixMlo1+2;sizes(2)=ixMhi2-ixMlo2+2
     sizes(3)=ixMhi3-ixMlo3+2;
     sizes(ndim+1)=3
@@ -275,7 +198,7 @@ contains
     call MPI_TYPE_CREATE_SUBARRAY(ndim+1,sizes,subsizes,start,&
         MPI_ORDER_FORTRAN,MPI_DOUBLE_PRECISION, type_block_xc_io,ierrmpi)
     call MPI_TYPE_COMMIT(type_block_xc_io,ierrmpi)
-  
+
     sizes(1)=ixMhi1-ixMlo1+1;sizes(2)=ixMhi2-ixMlo2+1
     sizes(3)=ixMhi3-ixMlo3+1;
     sizes(ndim+1)=nw+nwauxio
@@ -286,7 +209,7 @@ contains
     call MPI_TYPE_CREATE_SUBARRAY(ndim+1,sizes,subsizes,start,&
         MPI_ORDER_FORTRAN,MPI_DOUBLE_PRECISION, type_block_wcc_io,ierrmpi)
     call MPI_TYPE_COMMIT(type_block_wcc_io,ierrmpi)
-  
+
     sizes(1)=ixMhi1-ixMlo1+2;sizes(2)=ixMhi2-ixMlo2+2
     sizes(3)=ixMhi3-ixMlo3+2;
     sizes(ndim+1)=nw+nwauxio
@@ -297,7 +220,7 @@ contains
     call MPI_TYPE_CREATE_SUBARRAY(ndim+1,sizes,subsizes,start,&
         MPI_ORDER_FORTRAN,MPI_DOUBLE_PRECISION, type_block_wc_io,ierrmpi)
     call MPI_TYPE_COMMIT(type_block_wc_io,ierrmpi)
-  
+
   end subroutine init_comm_types
 
   !> Exit MPI-AMRVAC with an error message
@@ -307,10 +230,10 @@ contains
     !$acc routine
 #endif
     use mod_global_parameters
-  
+
     character(len=*), intent(in) :: message !< The error message
     integer                      :: ierrcode
-  
+
     write(*, *) "ERROR for processor", mype, ":"
 
 #ifdef _OPENACC
@@ -320,7 +243,7 @@ contains
     write(*, *) trim(message)
     call MPI_ABORT(icomm, ierrcode, ierrmpi)
 #endif
-  
+
   end subroutine mpistop
 
   subroutine mpistop_gpu()
@@ -332,6 +255,6 @@ contains
     write(*, *) "ERROR for processor", mype
     STOP
   end subroutine mpistop_gpu
-        
-  
+
+
 end module mod_comm_lib

--- a/src/mod_ghostcells_update.fpp
+++ b/src/mod_ghostcells_update.fpp
@@ -91,7 +91,7 @@ module mod_ghostcells_update
   ! sizes of buffer arrays for center-grid variable for siblings and restrict
   integer, dimension(:), allocatable :: recvrequest_c_sr, sendrequest_c_sr
   integer, dimension(:,:), allocatable :: recvstatus_c_sr, sendstatus_c_sr
-  
+
   ! MPI requests and status for srl neighbor exchange, used with nprocs_info
   integer, dimension(:), allocatable :: recv_srl_nb, send_srl_nb
   integer, dimension(:,:), allocatable :: recvstatus_srl_nb, sendstatus_srl_nb
@@ -167,13 +167,13 @@ contains
      ! .. local ..
      integer, parameter                        :: i1min=-1, i2min=-1, i3min=-1
      integer                                   :: id, idd
-     
+
      i3  = ceiling(dble(i)/9.0d0) - 1 + i3min
      id  = i - 9 * (i3-i3min)
      i2  = ceiling(dble(id)/3.0d0) -1 + i2min
      idd = id - 3 * (i2-i2min)
      i1  = idd + i1min - 1
-     
+
    end subroutine idecode
 
   subroutine init_bc()
@@ -1258,7 +1258,7 @@ contains
     type(wbuffer) :: pwbuf(npwbuf)
 
     integer :: ix1,ix2,ix3, iw, inb, i, Nx1, Nx2, Nx3, ienc, imaxigrids
-    
+
     time_bcin=MPI_WTIME()
 
     call nvtxStartRange("getbc",2)
@@ -1327,7 +1327,7 @@ contains
        isend_r=0
        isend_p=0
     end if
-    
+
     ! MPI receive SRL
     do inb = 1, nbprocs_info%nbprocs_srl
 !       !$acc host_data use_device(nbprocs_info%srl_rcv(inb)%buffer, nbprocs_info%srl_info_rcv(inb)%buffer)
@@ -1349,19 +1349,19 @@ contains
     do inb = 1, nbprocs_info%nbprocs_srl
        do i = 1, imaxigrids
           if (i > nbprocs_info%srl(inb)%nigrids) cycle
-          
+
           igrid = nbprocs_info%srl(inb)%igrid(i)
           ienc = nbprocs_info%srl(inb)%iencode(i)
           ibuf_start = nbprocs_info%srl(inb)%ibuf_start(i)
           call idecode( i1, i2, i3, ienc )
           iib1=idphyb(1,igrid); iib2=idphyb(2,igrid); iib3=idphyb(3,igrid)
-          
+
           ! now fill the data and info buffers
           ixSmin1=ixS_srl_min1(iib1,i1); ixSmax1=ixS_srl_max1(iib1,i1)
           ixSmin2=ixS_srl_min2(iib2,i2); ixSmax2=ixS_srl_max2(iib2,i2)
           ixSmin3=ixS_srl_min3(iib3,i3); ixSmax3=ixS_srl_max3(iib3,i3)
           Nx1=ixSmax1-ixSmin1+1; Nx2=ixSmax2-ixSmin2+1; Nx3=ixSmax3-ixSmin3+1
-          
+
           !$acc loop collapse(4) vector independent
           do iw = nwhead, nwtail
              do ix3 = ixSmin3, ixSmax3
@@ -1380,7 +1380,7 @@ contains
           end do
 
 !          print *, 'sending', neighbor(1,i1,i2,i3,igrid), -i1, -i2, -i3
-          
+
           nbprocs_info%srl_info_send(inb)%buffer( 1 + 3 * (i - 1) : 3 * i ) = &
                [neighbor(1,i1,i2,i3,igrid), ienc, ibuf_start]
        end do
@@ -1390,7 +1390,7 @@ contains
        !$acc update host(nbprocs_info%srl_info_send(inb)%buffer)
        !$acc update host(nbprocs_info%srl_send(inb)%buffer)
     end do
-       
+
     ! MPI send SRL
     do inb = 1, nbprocs_info%nbprocs_srl
 !       !$acc host_data use_device(nbprocs_info%srl_send(inb)%buffer, nbprocs_info%srl_info_send(inb)%buffer)
@@ -1402,7 +1402,7 @@ contains
             MPI_INTEGER, nbprocs_info%nbprocs_srl_list(inb), 2, icomm, send_srl_nb(nbprocs_info%nbprocs_srl + inb), ierrmpi)
 !       !$acc end host_data
     end do
-    
+
     ! fill ghost-cell values of sibling blocks
     !$OMP PARALLEL DO SCHEDULE(dynamic) PRIVATE(igrid,iib1,iib2,iib3)
     !$acc parallel loop gang collapse(2) independent
@@ -1450,7 +1450,7 @@ contains
        !$acc update device(nbprocs_info%srl_info_rcv(inb)%buffer)
        !$acc update device(nbprocs_info%srl_rcv(inb)%buffer)
     end do
-    
+
     ! unpack the MPI buffers
     !$acc parallel loop gang collapse(2) independent
     do inb = 1, nbprocs_info%nbprocs_srl
@@ -1460,19 +1460,19 @@ contains
           igrid       = nbprocs_info%srl_info_rcv(inb)%buffer( 3 * (i - 1) + 1 )
           ienc        = nbprocs_info%srl_info_rcv(inb)%buffer( 3 * (i - 1) + 2 )
           ibuf_start  = nbprocs_info%srl_info_rcv(inb)%buffer( 3 * (i - 1) + 3 )
-          
+
           call idecode( i1, i2, i3, ienc )
           i1 = -i1; i2 = -i2; i3=-i3
 
 !          print *, 'received:', igrid, i1, i2, i3
-          
+
           iib1 = idphyb(1,igrid); iib2 = idphyb(2,igrid); iib3 = idphyb(3,igrid)
 
-          ixRmin1=ixR_srl_min1(iib1,i1); ixRmin2=ixR_srl_min2(iib2,i2) 
-          ixRmin3=ixR_srl_min3(iib3,i3); ixRmax1=ixR_srl_max1(iib1,i1) 
+          ixRmin1=ixR_srl_min1(iib1,i1); ixRmin2=ixR_srl_min2(iib2,i2)
+          ixRmin3=ixR_srl_min3(iib3,i3); ixRmax1=ixR_srl_max1(iib1,i1)
           ixRmax2=ixR_srl_max2(iib2,i2); ixRmax3=ixR_srl_max3(iib3,i3)
           Nx1=ixRmax1-ixRmin1+1; Nx2=ixRmax2-ixRmin2+1; Nx3=ixRmax3-ixRmin3+1
-          
+
           !$acc loop collapse(4) vector independent
           do iw = nwhead, nwtail
              do ix3 = ixRmin3, ixRmax3
@@ -2992,7 +2992,7 @@ contains
 
                        ! cell-centered coordinates of coarse grid point
                        ! here we temporarily use an equidistant grid
-                       xCo3=xComin3+(dble(ixCo3)-half)*dxCo3 
+                       xCo3=xComin3+(dble(ixCo3)-half)*dxCo3
                        do ixFi2 = ixFimin2,ixFimax2
                           ! cell-centered coordinates of fine grid point
                           ! here we temporarily use an equidistant grid
@@ -3005,7 +3005,7 @@ contains
 
                           ! cell-centered coordinates of coarse grid point
                           ! here we temporarily use an equidistant grid
-                          xCo2=xComin2+(dble(ixCo2)-half)*dxCo2 
+                          xCo2=xComin2+(dble(ixCo2)-half)*dxCo2
                           do ixFi1 = ixFimin1,ixFimax1
                              ! cell-centered coordinates of fine grid point
                              ! here we temporarily use an equidistant grid
@@ -3018,7 +3018,7 @@ contains
 
                              ! cell-centered coordinates of coarse grid point
                              ! here we temporarily use an equidistant grid
-                             xCo1=xComin1+(dble(ixCo1)-half)*dxCo1 
+                             xCo1=xComin1+(dble(ixCo1)-half)*dxCo1
 
                              !if(.not.slab) then
                              !   ^D&local_invdxCo^D=1.d0/psc(igrid)%dx({ixCo^DD},^D)\
@@ -3077,21 +3077,21 @@ contains
                                    signedfactorhalf1=-0.5d0
                                 end if
                                 eta1=signedfactorhalf1*(one-psb(igrid)%dvolume(ixFi1,ixFi2,&
-                                     ixFi3) /sum(psb(igrid)%dvolume(ix1:ix1+1,ixFi2,ixFi3))) 
+                                     ixFi3) /sum(psb(igrid)%dvolume(ix1:ix1+1,ixFi2,ixFi3)))
                                 if(xFi2>xCo2) then
                                    signedfactorhalf2=0.5d0
                                 else
                                    signedfactorhalf2=-0.5d0
                                 end if
                                 eta2=signedfactorhalf2*(one-psb(igrid)%dvolume(ixFi1,ixFi2,&
-                                     ixFi3) /sum(psb(igrid)%dvolume(ixFi1,ix2:ix2+1,ixFi3))) 
+                                     ixFi3) /sum(psb(igrid)%dvolume(ixFi1,ix2:ix2+1,ixFi3)))
                                 if(xFi3>xCo3) then
                                    signedfactorhalf3=0.5d0
                                 else
                                    signedfactorhalf3=-0.5d0
                                 end if
                                 eta3=signedfactorhalf3*(one-psb(igrid)%dvolume(ixFi1,ixFi2,&
-                                     ixFi3) /sum(psb(igrid)%dvolume(ixFi1,ixFi2,ix3:ix3+1))) 
+                                     ixFi3) /sum(psb(igrid)%dvolume(ixFi1,ixFi2,ix3:ix3+1)))
                                 !{eta^D=(xFi^D-xCo^D)*invdxCo^D &
                                 !      *two*(one-block%dvolume(ixFi^DD) &
                                 !      /sum(block%dvolume(ix^D:ix^D+1^D%ixFi^DD))) \}

--- a/src/mod_ghostcells_update.fpp
+++ b/src/mod_ghostcells_update.fpp
@@ -1330,14 +1330,14 @@ contains
 
     ! MPI receive SRL
     do inb = 1, nbprocs_info%nbprocs_srl
-!       !$acc host_data use_device(nbprocs_info%srl_rcv(inb)%buffer, nbprocs_info%srl_info_rcv(inb)%buffer)
+      !$acc host_data use_device(nbprocs_info%srl_rcv(inb)%buffer, nbprocs_info%srl_info_rcv(inb)%buffer)
        call MPI_IRECV(nbprocs_info%srl_rcv(inb)%buffer, &
             size(nbprocs_info%srl_rcv(inb)%buffer), &
             MPI_DOUBLE_PRECISION, nbprocs_info%nbprocs_srl_list(inb), 1, icomm, recv_srl_nb(inb), ierrmpi)
        call MPI_IRECV(nbprocs_info%srl_info_rcv(inb)%buffer, &
             size(nbprocs_info%srl_info_rcv(inb)%buffer), &
             MPI_INTEGER, nbprocs_info%nbprocs_srl_list(inb), 2, icomm, recv_srl_nb(nbprocs_info%nbprocs_srl + inb), ierrmpi)
-!       !$acc end host_data
+      !$acc end host_data
     end do
 
     ! fill the SRL send buffers on GPU
@@ -1379,28 +1379,21 @@ contains
              end do
           end do
 
-!          print *, 'sending', neighbor(1,i1,i2,i3,igrid), -i1, -i2, -i3
-
           nbprocs_info%srl_info_send(inb)%buffer( 1 + 3 * (i - 1) : 3 * i ) = &
                [neighbor(1,i1,i2,i3,igrid), ienc, ibuf_start]
        end do
     end do
 
-    do inb = 1, nbprocs_info%nbprocs_srl
-       !$acc update host(nbprocs_info%srl_info_send(inb)%buffer)
-       !$acc update host(nbprocs_info%srl_send(inb)%buffer)
-    end do
-
     ! MPI send SRL
     do inb = 1, nbprocs_info%nbprocs_srl
-!       !$acc host_data use_device(nbprocs_info%srl_send(inb)%buffer, nbprocs_info%srl_info_send(inb)%buffer)
+      !$acc host_data use_device(nbprocs_info%srl_send(inb)%buffer, nbprocs_info%srl_info_send(inb)%buffer)
        call MPI_ISEND(nbprocs_info%srl_send(inb)%buffer, &
             size(nbprocs_info%srl_send(inb)%buffer), &
             MPI_DOUBLE_PRECISION, nbprocs_info%nbprocs_srl_list(inb), 1, icomm, send_srl_nb(inb), ierrmpi)
        call MPI_ISEND(nbprocs_info%srl_info_send(inb)%buffer, &
             size(nbprocs_info%srl_info_send(inb)%buffer), &
             MPI_INTEGER, nbprocs_info%nbprocs_srl_list(inb), 2, icomm, send_srl_nb(nbprocs_info%nbprocs_srl + inb), ierrmpi)
-!       !$acc end host_data
+      !$acc end host_data
     end do
 
     ! fill ghost-cell values of sibling blocks
@@ -1445,11 +1438,6 @@ contains
 
     call MPI_WAITALL(nbprocs_info%nbprocs_srl*2, recv_srl_nb, recvstatus_srl_nb, ierrmpi)
     call MPI_WAITALL(nbprocs_info%nbprocs_srl*2, send_srl_nb, sendstatus_srl_nb, ierrmpi)
-
-    do inb = 1, nbprocs_info%nbprocs_srl
-       !$acc update device(nbprocs_info%srl_info_rcv(inb)%buffer)
-       !$acc update device(nbprocs_info%srl_rcv(inb)%buffer)
-    end do
 
     ! unpack the MPI buffers
     !$acc parallel loop gang collapse(2) independent
@@ -1654,10 +1642,10 @@ contains
              itag=(3**3+4**3)*(igrid-1)+(i1+1)*3**(1-1)+(i2+1)*3**(2-1)+(i3+&
                   1)*3**(3-1)
              istep = psb(igrid)%istep
-!             !$acc host_data use_device(bg(istep)%w)
+            !$acc host_data use_device(bg(istep)%w)
              call MPI_IRECV(bg(istep)%w(:,:,:,:,igrid),1,type_recv_srl(iib1,iib2,iib3,i1,i2,&
                   i3), ipe_neighbor,itag,icomm,recvrequest_c_sr(irecv_c),ierrmpi)
-!             !$acc end host_data
+            !$acc end host_data
              if(stagger_grid) then
                 irecv_srl=irecv_srl+1
                 call MPI_IRECV(recvbuffer_srl(ibuf_recv_srl),&
@@ -1684,10 +1672,10 @@ contains
                 itag=(3**3+4**3)*(ineighbor-1)+(n_i1+1)*3**(1-1)+(n_i2+1)*3**(2-1)+&
                      (n_i3+1)*3**(3-1)
                 istep = psb(igrid)%istep
-!                !$acc host_data use_device(bg(istep)%w)
+               !$acc host_data use_device(bg(istep)%w)
                 call MPI_ISEND(bg(istep)%w(:,:,:,:,igrid),1,type_send_srl(iib1,iib2,iib3,i1,i2,&
                      i3), ipe_neighbor,itag,icomm,sendrequest_c_sr(isend_c),ierrmpi)
-!                !$acc end host_data
+               !$acc end host_data
                 if(stagger_grid) then
                    ibuf_start=ibuf_send_srl
                    do idir=1,ndim

--- a/src/mod_nvtx.fpp
+++ b/src/mod_nvtx.fpp
@@ -1,6 +1,6 @@
 module mod_nvtx
 
-#ifdef __NVCOMPILER 
+#ifdef NVTX
 use iso_c_binding
 implicit none
 
@@ -17,7 +17,7 @@ type, bind(C):: nvtxEventAttributes
   integer(C_INT):: payloadType=0 ! NVTX_PAYLOAD_UNKNOWN = 0
   integer(C_INT):: reserved0
   integer(C_INT64_T):: payload   ! union uint,int,double
-  integer(C_INT):: messageType=1  ! NVTX_MESSAGE_TYPE_ASCII     = 1 
+  integer(C_INT):: messageType=1  ! NVTX_MESSAGE_TYPE_ASCII     = 1
   type(C_PTR):: message  ! ascii char
 end type
 


### PR DESCRIPTION
Each MPI ranks sets the GPU it uses in the main program, this must be done _before_ any data is initialized on the GPU, i.e. before any `use <module>` statements that would load some data on the GPU. To handle this, the rest of the main program is moved to a subroutine.

The ghostcell exchange itself uses buffers on the GPU that are allocated within another allocatable. This is not handled correctly by OpenMPI 4.x, instead of copying the device buffers it copies the host buffers. Therefore we now require OpenMPI 5.x as minimum version. 