### PR TITLE
Use gfortran 14/15 in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        FC_compiler: [gfortran-12]
-        CC_compiler: [gcc-12]
+        FC_compiler: [gfortran-15]
+        CC_compiler: [gcc-15]
         suite: [hd]
 
     env:
@@ -38,10 +38,11 @@ jobs:
             sudo apt-get install openmpi-bin libopenmpi-dev
           else
             brew install ${{ env.GCC_PACKAGE_NAME }}
+            brew install open-mpi
             brew install grep
             brew install md5sha1sum
             ln -s $(which ${{ matrix.FC_compiler }}) /usr/local/bin/gfortran
-            brew install open-mpi --build-from-source
+            
           fi
       - name: check compiler versions
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,10 +38,10 @@ jobs:
             sudo apt-get install openmpi-bin libopenmpi-dev
           else
             brew install ${{ env.GCC_PACKAGE_NAME }}
-            brew install open-mpi
             brew install grep
             brew install md5sha1sum
             ln -s $(which ${{ matrix.FC_compiler }}) /usr/local/bin/gfortran
+            brew install open-mpi --build-from-source
           fi
       - name: check compiler versions
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,17 +13,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        FC_compiler: [gfortran-15]
-        CC_compiler: [gcc-15]
         suite: [hd]
+        include:
+          - os: ubuntu-latest
+            FC_compiler: gfortran-14
+            CC_compiler: gcc-14
+          - os: macos-latest
+            FC_compiler: gfortran-15
+            CC_compiler: gcc-15
+            OSX_GCC_PACKAGE_NAME: gcc@15
 
     env:
       CC: ${{ matrix.CC_compiler }}
       FC: ${{ matrix.FC_compiler }}
       AMRVAC_DIR: ${{ github.workspace }}
-      GCC_PACKAGE_NAME: gcc@12
-
+      
     runs-on: ${{ matrix.os }}
 
     name: ${{ matrix.os }} / ${{ matrix.FC_compiler }} / ${{ matrix.suite }}
@@ -37,7 +41,7 @@ jobs:
             sudo apt-get install ${{ matrix.FC_compiler }}
             sudo apt-get install openmpi-bin libopenmpi-dev
           else
-            brew install ${{ env.GCC_PACKAGE_NAME }}
+            brew install ${{ matrix.OSX_GCC_PACKAGE_NAME }}
             brew install open-mpi
             brew install grep
             brew install md5sha1sum

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,12 +21,13 @@ jobs:
           - os: macos-latest
             FC_compiler: gfortran-15
             CC_compiler: gcc-15
-            OSX_GCC_PACKAGE_NAME: gcc@15
+            
 
     env:
       CC: ${{ matrix.CC_compiler }}
       FC: ${{ matrix.FC_compiler }}
       AMRVAC_DIR: ${{ github.workspace }}
+      OSX_GCC_PACKAGE_NAME: gcc@15
       
     runs-on: ${{ matrix.os }}
 
@@ -41,7 +42,7 @@ jobs:
             sudo apt-get install ${{ matrix.FC_compiler }}
             sudo apt-get install openmpi-bin libopenmpi-dev
           else
-            brew install ${{ matrix.OSX_GCC_PACKAGE_NAME }}
+            brew install ${{ env.OSX_GCC_PACKAGE_NAME }}
             brew install open-mpi
             brew install grep
             brew install md5sha1sum

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,15 +13,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
+        FC_compiler: [gfortran-14]
+        CC_compiler: [gcc-14]
         suite: [hd]
         include:
-          - os: ubuntu-latest
-            FC_compiler: gfortran-14
-            CC_compiler: gcc-14
           - os: macos-latest
             FC_compiler: gfortran-15
             CC_compiler: gcc-15
-            
 
     env:
       CC: ${{ matrix.CC_compiler }}


### PR DESCRIPTION
The OSX runner has a new OS, where MPI is no longer compiled with gfortran 12, but 15. Ubuntu however doesn't have gfortran15 yet. I've changed the CI to use gfortran 14 for ubuntu and 15 for osx.