### PR TITLE
Add MHD HLL support

### DIFF
--- a/src/io/mod_input_output.fpp
+++ b/src/io/mod_input_output.fpp
@@ -214,8 +214,6 @@ contains
     character(len=std_len) :: typesourcesplit
     !> Which flux scheme of spatial discretization to use (per grid level)
     character(len=std_len), allocatable :: flux_scheme(:)
-    !> Which type of the maximal bound speed of Riemann fan to use
-    character(len=std_len) :: typeboundspeed
     !> Which time stepper to use
     character(len=std_len) :: time_stepper
     !> Which time integrator to use
@@ -263,9 +261,9 @@ contains
 
     namelist /methodlist/ time_stepper,time_integrator, source_split_usr,&
        typesourcesplit,local_timestep,dimsplit,typedimsplit,flux_scheme,&
-       limiter,gradient_limiter,cada3_radius,loglimit,typeboundspeed,&
-        H_correction,typetvd,typeentropy,entropycoef,typeaverage, typegrad,&
-       typediv,typecurl,nxdiffusehllc, flathllc, tvdlfeps,flatcd,flatsh,&
+       limiter,gradient_limiter,cada3_radius,loglimit,&
+       H_correction, typegrad,&
+       typediv,typecurl,flatcd,flatsh,&
        rk2_alfa,imex222_lambda,ssprk_order,rk3_switch,imex_switch,&
        small_temperature,small_pressure,small_density, small_values_method,&
         small_values_daverage, fix_small_values, check_small_values,&
@@ -482,10 +480,6 @@ contains
 
 
     ! Defaults for discretization methods
-    typeaverage     = 'default'
-    tvdlfeps        = one
-    nxdiffusehllc   = 0
-    flathllc        = .false.
     slowsteps       = -1
     courantpar      = 0.8d0
     typecourant     = 'maxsum'
@@ -499,8 +493,6 @@ contains
     schmid_rad1 = 1.d0
     schmid_rad2 = 1.d0
     schmid_rad3 = 1.d0
-    typetvd         = 'roe'
-    typeboundspeed  = 'Einfeldt'
     source_split_usr= .false.
     time_stepper    = 'twostep'
     time_integrator = 'default'
@@ -532,12 +524,10 @@ contains
     R_opt_thick=1.d0
     dat_resolution=.false.
 
-    allocate(flux_scheme(nlevelshi),typepred1(nlevelshi),&
-       flux_method(nlevelshi))
+    allocate(flux_scheme(nlevelshi), flux_method(nlevelshi))
     allocate(limiter(nlevelshi),gradient_limiter(nlevelshi))
     do level=1,nlevelshi
        flux_scheme(level) = 'tvdlf'
-       typepred1(level)   = 0
        limiter(level)     = 'minmod'
        gradient_limiter(level) = 'minmod'
     end do
@@ -547,12 +537,6 @@ contains
     typesourcesplit = 'sfs'
     allocate(loglimit(nw))
     loglimit(1:nw)  = .false.
-
-    allocate(typeentropy(nw))
-
-    do iw=1,nw
-       typeentropy(iw)='nul'      ! Entropy fix type
-    end do
 
     dtdiffpar     = 0.5d0
     dtpar         = -1.d0
@@ -786,21 +770,31 @@ contains
        call mpistop("Error from read_par_files: no such typecourant!")
     end select
 
+    ! =========================================================================
+    ! Flux scheme parsing and physics compatibility validation
+    ! =========================================================================
     do level=1,nlevelshi
        select case (flux_scheme(level))
        case ('hll')
           flux_method(level)=fs_hll
+          if (physics_type=='ffhd') then
+             call mpistop(trim(flux_scheme(level))//" flux scheme is not compatible with "//trim(physics_type))
+          end if
        case ('hllc')
           flux_method(level)=fs_hllc
+          if (physics_type=='mhd' .or. physics_type=='ffhd') then
+             call mpistop(trim(flux_scheme(level))//" flux scheme is not compatible with "//trim(physics_type))
+          end if
        case ('tvdlf')
           flux_method(level)=fs_tvdlf
        case default
-          call mpistop("unkown or bad flux scheme")
+          call mpistop("unknown or bad flux scheme: "//trim(flux_scheme(level)))
        end select
     end do
 
-    ! finite difference scheme fd need global maximal speed
-    if(any(flux_scheme=='fd')) need_global_cmax=.true.
+    ! =========================================================================
+    ! Limiter and spatial operator parsing
+    ! =========================================================================
     if(any(limiter=='schmid1')) need_global_a2max=.true.
 
     ! initialize type_curl
@@ -1971,18 +1965,6 @@ contains
       call mpistop("Reset w_refine_weight so the sum is 1.d0")
     end if
 
-    select case (typeboundspeed)
-    case('Einfeldt')
-      boundspeed=1
-    case('cmaxmean')
-      boundspeed=2
-    case('cmaxleftright')
-      boundspeed=3
-    case default
-      call mpistop&
-         ("set typeboundspeed='Einfieldt' or 'cmaxmean' or 'cmaxleftright'")
-    end select
-
     if (mype==0) write(unitterm, '(A30)', advance='no') 'Refine estimation: '
 
     select case (refine_criterion)
@@ -2043,8 +2025,8 @@ contains
 
     deallocate(flux_scheme)
 
-    !$acc update device(tvdlfeps,ixGhi1,ixGhi2,ixGhi3,ixGshi1,ixGshi2,ixGshi3,schmid_rad1,schmid_rad2,schmid_rad3,cada3_radius)
-    !$acc update device(fix_small_values,H_correction,type_limiter, boundspeed, max_blocks)
+    !$acc update device(ixGhi1,ixGhi2,ixGhi3,ixGshi1,ixGshi2,ixGshi3,schmid_rad1,schmid_rad2,schmid_rad3,cada3_radius)
+    !$acc update device(fix_small_values,H_correction,type_limiter, max_blocks)
     !$acc update device(rk_beta11,rk_beta22,rk_beta33,rk_beta44,rk_c2,rk_c3,rk_c4)
     !$acc update device(rk_alfa21,rk_alfa22,rk_alfa31,rk_alfa33,rk_alfa41,rk_alfa44)
     !$acc update device(rk_beta54,rk_beta55,rk_alfa53,rk_alfa54,rk_alfa55,rk_c5)

--- a/src/mhd/mod_mhd_templates.fpp
+++ b/src/mhd/mod_mhd_templates.fpp
@@ -562,7 +562,9 @@ end subroutine addsource_nonlocal
   end subroutine get_flux
 #:enddef
 
-#:def get_cmax()  
+#:def get_cmax()
+!> Returns maximum local signal speed |v_n| + c_f (fast magnetosonic) from primitive state u in direction flux_dim;
+!> used in LLF/TVDLF flux estimation.
 pure real(dp) function get_cmax(u, x, flux_dim) result(wC)
   !$acc routine seq
   real(dp), intent(in)  :: u(nw_phys)
@@ -590,5 +592,43 @@ pure real(dp) function get_cs2(u) result(cs2)
   cs2 = phys_gamma*u(iw_e)/u(iw_rho)
 end function get_cs2
 #:enddef
+
+
+#:def estimate_speeds_minmax()
+!> Davis (1988) min/max wave speed estimates wL = min(v_n - c_f), wR = max(v_n + c_f) (fast magnetosonic) over left/right states;
+!> used in HLL flux estimation.
+subroutine estimate_speeds_minmax(uL, uR, xC, flux_dim, wL, wR)
+  !$acc routine seq
+  real(dp), intent(in)  :: uL(nw_phys), uR(nw_phys)
+  real(dp), intent(in)  :: xC(ndim)
+  integer, intent(in)   :: flux_dim
+  real(dp), intent(out) :: wL, wR
+
+  real(dp) :: inv_rho, cs2, cA2, cAn2, sum2, discriminant, cfL, cfR
+
+  ! Left state
+  inv_rho = 1.0_dp / uL(iw_rho)
+  cs2 = mhd_gamma * uL(iw_e) * inv_rho
+  cA2 = (uL(iw_mag(1))**2 + uL(iw_mag(2))**2 + uL(iw_mag(3))**2) * inv_rho
+  cAn2 = uL(iw_mag(flux_dim))**2 * inv_rho
+  sum2 = cs2 + cA2
+  discriminant = max(sum2**2 - 4.0_dp*cs2*cAn2, 0.0_dp)
+  cfL = sqrt(0.5_dp * (sum2 + sqrt(discriminant)))
+
+  ! Right state
+  inv_rho = 1.0_dp / uR(iw_rho)
+  cs2 = mhd_gamma * uR(iw_e) * inv_rho
+  cA2 = (uR(iw_mag(1))**2 + uR(iw_mag(2))**2 + uR(iw_mag(3))**2) * inv_rho
+  cAn2 = uR(iw_mag(flux_dim))**2 * inv_rho
+  sum2 = cs2 + cA2
+  discriminant = max(sum2**2 - 4.0_dp*cs2*cAn2, 0.0_dp)
+  cfR = sqrt(0.5_dp * (sum2 + sqrt(discriminant)))
+  
+  wL = min(uL(iw_mom(flux_dim)) - cfL, uR(iw_mom(flux_dim)) - cfR)
+  wR = max(uL(iw_mom(flux_dim)) + cfL, uR(iw_mom(flux_dim)) + cfR)
+
+end subroutine estimate_speeds_minmax
+#:enddef
+
 
 #:endif

--- a/src/mod_finite_volume.fpp
+++ b/src/mod_finite_volume.fpp
@@ -38,6 +38,7 @@ contains
     ixImin3,ixImax1,ixImax2,ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,&
     ixOmax3, idimsmin,idimsmax, qtC, bga, qt, bgb, fC, fE)
     use mod_global_parameters
+    use mod_comm_lib, only: mpistop
 
     double precision, intent(in)                                       :: qdt,&
       dtfactor, qtC, qt
@@ -75,9 +76,7 @@ contains
             ixOmax3, idimsmin,idimsmax, qtC, bga, qt, bgb, fC, fE)
 #:endfor
     case default
-      call finite_volume_local_muscl_llf(qdt, dtfactor, ixImin1,ixImin2,&
-            ixImin3,ixImax1,ixImax2,ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,&
-            ixOmax3, idimsmin,idimsmax, qtC, bga, qt, bgb, fC, fE)
+      call mpistop("finite_volume_local: unknown flux scheme")
     end select
 end subroutine finite_volume_local
 
@@ -328,7 +327,8 @@ end subroutine finite_volume_local
   end subroutine riemann_hll_prim
 
 
-  !> One-face HLLC numerical flux from primitive L/R states.
+  !> One-face HLLC numerical flux from primitive L/R states (HD only).
+  !> Uses scalar pressure assumption; not valid for MHD (use HLLD instead).
   !> Reference: Toro (2010), chapter 10 (Variant 2)
   subroutine riemann_hllc_prim(uL, uR, xC, flux_dim, F)
     !$acc routine seq

--- a/src/mod_global_parameters.fpp
+++ b/src/mod_global_parameters.fpp
@@ -590,10 +590,6 @@ module mod_global_parameters
   !> Which flux scheme of spatial discretization to use (per grid level)
   integer, allocatable :: flux_method(:)
 
-  !> The spatial discretization for the predictor step when using a two
-  !> step PC method
-  integer, allocatable :: typepred1(:)
-
   !> flux schemes
   integer, parameter :: fs_hll=1
   integer, parameter :: fs_hllc=2
@@ -646,31 +642,15 @@ module mod_global_parameters
   !> Limiter used for prolongation to refined grids and ghost cells
   integer :: prolong_limiter=0
 
-  !> Which type of entropy fix to use with Riemann-type solvers
-  character(len=std_len), allocatable :: typeentropy(:)
-
-  !> Which type of TVD method to use
-  character(len=std_len) :: typetvd
-
-  !> bound (left/min and right.max) speed of Riemann fan
-  integer :: boundspeed
-  !$acc declare create(boundspeed)
-
-  character(len=std_len) :: typeaverage
   character(len=std_len) :: typedimsplit
   character(len=std_len) :: geometry_name='default'
   character(len=std_len) :: typepoly
-  !$acc declare copyin(typeaverage, typedimsplit, geometry_name, typepoly)
-
-  integer                       :: nxdiffusehllc
-  double precision, allocatable :: entropycoef(:)
-  double precision              :: tvdlfeps
-  !$acc declare create(nxdiffusehllc, entropycoef, tvdlfeps)
+  !$acc declare copyin(typedimsplit, geometry_name, typepoly)
 
   logical, allocatable          :: loglimit(:), logflag(:)
   !$acc declare create(loglimit, logflag)
-  logical                       :: flathllc,flatcd,flatsh
-  !$acc declare create(flathllc, flatcd, flatsh)
+  logical                       :: flatcd,flatsh
+  !$acc declare create(flatcd, flatsh)
   !> Use split or unsplit way to add user's source terms, default: unsplit
   logical                       :: source_split_usr
   !$acc declare create(source_split_usr)

--- a/src/physics/mod_physics_dummies.fpp
+++ b/src/physics/mod_physics_dummies.fpp
@@ -2,13 +2,18 @@
 
 #:def get_cs2()
 !> obtain the squared sound speed
-pure real(dp) function get_cs2(u) result(cs2)
+real(dp) function get_cs2(u) result(cs2)
   !$acc routine seq
+  use mod_comm_lib, only: mpistop, mpistop_gpu
   real(dp), intent(in)  :: u(nw_phys)
 
-  ! provide nonsensical soundspeed so the user notices:
-  cs2 = -1.0d0
-  
+#ifdef _CRAYFTN
+  call mpistop_gpu()
+#else
+  call mpistop("get_cs2 not implemented for this physics module")
+#endif
+  cs2 = -1.0d0  ! unreachable
+
 end function get_cs2
 #:enddef
 
@@ -16,13 +21,19 @@ end function get_cs2
 #:def estimate_speeds_minmax()
 subroutine estimate_speeds_minmax(uL, uR, xC, flux_dim, wL, wR)
   !$acc routine seq
+  use mod_comm_lib, only: mpistop, mpistop_gpu
   real(dp), intent(in)  :: uL(nw_phys), uR(nw_phys)
   real(dp), intent(in)  :: xC(ndim)
   integer, intent(in)   :: flux_dim
   real(dp), intent(out) :: wL, wR
 
-  wL = -1._dp
-  WR = -1._dp
+#ifdef _CRAYFTN
+  call mpistop_gpu()
+#else
+  call mpistop("estimate_speeds_minmax not implemented for this physics module")
+#endif
+  wL = -1._dp  ! unreachable
+  wR = -1._dp
 
 end subroutine estimate_speeds_minmax
 #:enddef
@@ -31,12 +42,18 @@ end subroutine estimate_speeds_minmax
 #:def estimate_speeds_toro_pvrs()
 subroutine estimate_speeds_toro_pvrs(uL, uR, xC, flux_dim, sL, sR)
   !$acc routine seq
+  use mod_comm_lib, only: mpistop, mpistop_gpu
   real(dp), intent(in)  :: uL(nw_phys), uR(nw_phys)
   real(dp), intent(in)  :: xC(ndim)
   integer,  intent(in)  :: flux_dim
   real(dp), intent(out) :: sL, sR
 
-  sL = -1._dp
+#ifdef _CRAYFTN
+  call mpistop_gpu()
+#else
+  call mpistop("estimate_speeds_toro_pvrs not implemented for this physics module")
+#endif
+  sL = -1._dp  ! unreachable
   sR = -1._dp
 
 end subroutine estimate_speeds_toro_pvrs

--- a/src/physics/mod_physics_dummies.fpp
+++ b/src/physics/mod_physics_dummies.fpp
@@ -1,18 +1,20 @@
 ! Dummy routines which can be overwritten by a physics-dependent implementation
+! On non-Cray compilers, these call mpistop with a descriptive message.
+! On Cray, STOP cannot be inlined into OpenACC kernels, so dummies just return -1. 
 
 #:def get_cs2()
 !> obtain the squared sound speed
 real(dp) function get_cs2(u) result(cs2)
   !$acc routine seq
-  use mod_comm_lib, only: mpistop, mpistop_gpu
+#ifndef _CRAYFTN
+  use mod_comm_lib, only: mpistop
+#endif
   real(dp), intent(in)  :: u(nw_phys)
 
-#ifdef _CRAYFTN
-  call mpistop_gpu()
-#else
+#ifndef _CRAYFTN
   call mpistop("get_cs2 not implemented for this physics module")
 #endif
-  cs2 = -1.0d0  ! unreachable
+  cs2 = -1.0d0
 
 end function get_cs2
 #:enddef
@@ -21,18 +23,18 @@ end function get_cs2
 #:def estimate_speeds_minmax()
 subroutine estimate_speeds_minmax(uL, uR, xC, flux_dim, wL, wR)
   !$acc routine seq
-  use mod_comm_lib, only: mpistop, mpistop_gpu
+#ifndef _CRAYFTN
+  use mod_comm_lib, only: mpistop
+#endif
   real(dp), intent(in)  :: uL(nw_phys), uR(nw_phys)
   real(dp), intent(in)  :: xC(ndim)
   integer, intent(in)   :: flux_dim
   real(dp), intent(out) :: wL, wR
 
-#ifdef _CRAYFTN
-  call mpistop_gpu()
-#else
+#ifndef _CRAYFTN
   call mpistop("estimate_speeds_minmax not implemented for this physics module")
 #endif
-  wL = -1._dp  ! unreachable
+  wL = -1._dp
   wR = -1._dp
 
 end subroutine estimate_speeds_minmax
@@ -42,18 +44,18 @@ end subroutine estimate_speeds_minmax
 #:def estimate_speeds_toro_pvrs()
 subroutine estimate_speeds_toro_pvrs(uL, uR, xC, flux_dim, sL, sR)
   !$acc routine seq
-  use mod_comm_lib, only: mpistop, mpistop_gpu
+#ifndef _CRAYFTN
+  use mod_comm_lib, only: mpistop
+#endif
   real(dp), intent(in)  :: uL(nw_phys), uR(nw_phys)
   real(dp), intent(in)  :: xC(ndim)
   integer,  intent(in)  :: flux_dim
   real(dp), intent(out) :: sL, sR
 
-#ifdef _CRAYFTN
-  call mpistop_gpu()
-#else
+#ifndef _CRAYFTN
   call mpistop("estimate_speeds_toro_pvrs not implemented for this physics module")
 #endif
-  sL = -1._dp  ! unreachable
+  sL = -1._dp
   sR = -1._dp
 
 end subroutine estimate_speeds_toro_pvrs


### PR DESCRIPTION
- Implement `estimate_speeds_minmax` for MHD (fast magnetosonic wave speeds) enabling HLL flux scheme with MHD physics
- Added mpistops in physics dummy routines to crash immediately on unimplemented wave speed estimates, instead of silently returning bad values
- Check for invalid flux scheme / physics combinations at runtime (e.g. HLLC with MHD)
- Replace silent LLF fallback in `finite_volume_local` with mpistop
- Remove dead legacy flux scheme variables (`typepred1`, `typetvd`, `typeentropy`, `entropycoef`, `typeboundspeed`, `boundspeed`, `tvdlfeps`, `nxdiffusehllc`, `flathllc`, `typeaverage`) - none of these are hooked up to anything and are bound to cause confusion

To do:
- [x] Ensure all existing tests pass
- MHD blast wave tests
  - [x] `tvdlf` works (existing)
  - [x] `hll` works (new)
  - [x] `hllc` gives a correct startup error
- [x] Test compilation on Cray Fortran
