### PR TITLE
pre-allocate the coarse block storage just like for bg

### DIFF
--- a/src/amr/mod_amr_solution_node.fpp
+++ b/src/amr/mod_amr_solution_node.fpp
@@ -1728,7 +1728,9 @@ contains
     integer             :: ixGsmin1,ixGsmin2,ixGsmin3,ixGsmax1,ixGsmax2,&
        ixGsmax3
   
-    allocate(s%w(ixGmin1:ixGmax1,ixGmin2:ixGmax2,ixGmin3:ixGmax3,1:nw))
+!    allocate(s%w(ixGmin1:ixGmax1,ixGmin2:ixGmax2,ixGmin3:ixGmax3,1:nw))
+    s%w => bgc(1)%w(:,:,:,:,igrid)
+
 
     s%igrid=igrid
     s%w=0.d0

--- a/src/mod_ghostcells_update.fpp
+++ b/src/mod_ghostcells_update.fpp
@@ -1174,16 +1174,16 @@ contains
                       ixFi2=2*(ixCo2-ixCoMmin2)+ixMmin2
                       ixFi1=2*(ixCo1-ixCoMmin1)+ixMmin1
 
-                      psc(igrid)%w(ixCo1,ixCo2,ixCo3,iw) = 0.0d0
+                      bgc(1)%w(ixCo1,ixCo2,ixCo3,iw,igrid) = 0.0d0
                       do ix3 = ixFi3,ixFi3+1
                          do ix2 = ixFi2,ixFi2+1
                             do ix1 = ixFi1,ixFi1+1
-                               psc(igrid)%w(ixCo1,ixCo2,ixCo3,iw) = psc(igrid)%w(ixCo1,ixCo2,ixCo3,iw) &
+                               bgc(1)%w(ixCo1,ixCo2,ixCo3,iw,igrid) = bgc(1)%w(ixCo1,ixCo2,ixCo3,iw,igrid) &
                                     + bg(bgstep)%w(ix1,ix2,ix3,iw,igrid)
                             end do
                          end do
                       end do
-                      psc(igrid)%w(ixCo1,ixCo2,ixCo3,iw) = psc(igrid)%w(ixCo1,ixCo2,ixCo3,iw)*coFiRatio
+                      bgc(1)%w(ixCo1,ixCo2,ixCo3,iw,igrid) = bgc(1)%w(ixCo1,ixCo2,ixCo3,iw,igrid)*coFiRatio
 
                    end do
                 end do
@@ -1321,7 +1321,7 @@ contains
                            + Nx1 * (ix2-ixSmin2) &
                            + Nx1*Nx2 * (ix3-ixSmin3) &
                            + Nx1*Nx2*Nx3 * (iw-nwhead) &
-                           ) = psc(igrid)%w( ix1, ix2, ix3, iw)
+                           ) = bgc(1)%w( ix1, ix2, ix3, iw, igrid )
                    end do
                 end do
              end do
@@ -1445,8 +1445,8 @@ contains
                          do ix2=1,ixSmax2-ixSmin2+1
                             do ix1=1,ixSmax1-ixSmin1+1
                                bg(bgstep)%w(ixRmin1+ix1-1,ixRmin2+ix2-1,&
-                                    ixRmin3+ix3-1,iw,ineighbor) = psc(igrid)%w(ixSmin1+ix1-1,&
-                                    ixSmin2+ix2-1,ixSmin3+ix3-1,iw)
+                                    ixRmin3+ix3-1,iw,ineighbor) = bgc(1)%w(ixSmin1+ix1-1,&
+                                    ixSmin2+ix2-1,ixSmin3+ix3-1,iw, igrid)
                             end do
                          end do
                       end do
@@ -1700,8 +1700,8 @@ contains
                                   do ix3 =0, ixRmax3-ixRmin3
                                      do ix2 = 0, ixRmax2-ixRmin2
                                         do ix1 = 0, ixRmax1-ixRmin1
-                                           psc(ineighbor)%w(ixRmin1+ix1,ixRmin2+ix2,&
-                                                ixRmin3+ix3,iw) = bg(bgstep)%w(ixSmin1+ix1,&
+                                           bgc(1)%w(ixRmin1+ix1,ixRmin2+ix2,&
+                                                ixRmin3+ix3,iw,ineighbor) = bg(bgstep)%w(ixSmin1+ix1,&
                                                 ixSmin2+ix2,ixSmin3+ix3,iw, igrid)
                                         end do
                                      end do
@@ -1767,7 +1767,7 @@ contains
                            + Nx1*Nx2 * (ix3-ixRmin3) &
                            + Nx1*Nx2*Nx3 * (iw-nwhead) &
                            )
-                      psc(igrid)%w( ix1, ix2, ix3, iw ) = tempval
+                      bgc(1)%w( ix1, ix2, ix3, iw, igrid ) = tempval
                    end do
                 end do
              end do
@@ -1837,11 +1837,11 @@ contains
                                   jxCo2=ixCo2+kr(2,idims)
                                   jxCo3=ixCo3+kr(3,idims)
 
-                                  slopeL = psc(igrid)%w(ixCo1,ixCo2,ixCo3,iw) &
-                                       - psc(igrid)%w(hxCo1,hxCo2,hxCo3,iw)
+                                  slopeL = bgc(1)%w(ixCo1,ixCo2,ixCo3,iw,igrid) &
+                                       - bgc(1)%w(hxCo1,hxCo2,hxCo3,iw,igrid)
 
-                                  slopeR = psc(igrid)%w(jxCo1,jxCo2,jxCo3,iw) &
-                                       - psc(igrid)%w(ixCo1,ixCo2,ixCo3,iw)
+                                  slopeR = bgc(1)%w(jxCo1,jxCo2,jxCo3,iw,igrid) &
+                                       - bgc(1)%w(ixCo1,ixCo2,ixCo3,iw,igrid)
 
                                   slopeC = half * ( slopeR + slopeL )
 
@@ -1855,7 +1855,7 @@ contains
 
                                ! Interpolate from coarse cell using limited slopes
                                bg(bgstep)%w(ixFi1,ixFi2,ixFi3,iw,igrid) = &
-                                    psc(igrid)%w(ixCo1,ixCo2,ixCo3,iw) &
+                                    bgc(1)%w(ixCo1,ixCo2,ixCo3,iw, igrid) &
                                     + (slope(1)*eta1) + (slope(2)*eta2) + (slope(3)*eta3)
                             end do
 

--- a/src/mod_initialize.fpp
+++ b/src/mod_initialize.fpp
@@ -91,6 +91,16 @@ contains
        !$acc update device(bg(istep))
        !$acc enter data copyin( bg(istep)%w )
     end do
+    allocate( bgc(1) )
+    ixCoGmin1=1;ixCoGmin2=1;ixCoGmin3=1;
+    ixCoGmax1=(ixGhi1-2*nghostcells)/2+2*nghostcells
+    ixCoGmax2=(ixGhi2-2*nghostcells)/2+2*nghostcells
+    ixCoGmax3=(ixGhi3-2*nghostcells)/2+2*nghostcells;
+
+    allocate ( bgc(1)%w(ixCoGmin1:ixCoGmax1, ixCoGmin2:ixCoGmax2, &
+    ixCoGmin3:ixCoGmax3, 1:nw, 1:max_blocks) )
+     !$acc update device( bgc(1) )
+     !$acc enter data copyin( bgc(1)%w ) 
 
     do igrid = 1, max_blocks
        ps(igrid)%igrid  = igrid; ps(igrid)%istep  = 1

--- a/src/mod_physicaldata.fpp
+++ b/src/mod_physicaldata.fpp
@@ -116,8 +116,8 @@ module mod_physicaldata
   !$acc declare create(ps, ps1, ps2, ps3, ps4, psc)
 
   !> one block grid to rule them all
-  type(block_grid_t), dimension(:), allocatable, target   :: bg
-  !$acc declare create(bg)
+  type(block_grid_t), dimension(:), allocatable, target   :: bg, bgc
+  !$acc declare create(bg, bgc)
 
   !> array of physical blocks in reduced dimension
   type(state_sub), dimension(:), allocatable, target :: ps_sub


### PR DESCRIPTION
can replace the pointer usage on device in mod_ghostcells_update. This should be more robust (the other way is correct too...) Might even help with LUMI again since we use 'allocate once' memory instead of dynamically allocated pointers.

I have tested this on 4 H100 (snellius) with the sphere advection AMR test case using six grid levels.  
(this test also worked fine with psc)