### PR TITLE
Fixes for multi-GPU AMR on LUMI

### DIFF
--- a/src/amr/mod_amr_fct.fpp
+++ b/src/amr/mod_amr_fct.fpp
@@ -188,7 +188,6 @@ contains
     ixFismax1=ixFimax1;ixFismax2=ixFimax2;ixFismax3=ixFimax3;
 
 
-    associate(wCos=>sCo%ws, wFis=>sFi%ws,wCo=>sCo%w, wFi=>sFi%w)
     ! Assemble general indices
     ixGsmin1=sFi%ixGsmin1;ixGsmin2=sFi%ixGsmin2;ixGsmin3=sFi%ixGsmin3;
     ixGsmax1=sFi%ixGsmax1;ixGsmax2=sFi%ixGsmax2;ixGsmax3=sFi%ixGsmax3;
@@ -247,7 +246,7 @@ contains
       end if
       ! Convert fine fields to fluxes
       bfluxFi(ixFisEmin1:ixFisEmax1,ixFisEmin2:ixFisEmax2,&
-         ixFisEmin3:ixFisEmax3,idim1)=wFis(ixFisEmin1:ixFisEmax1,&
+         ixFisEmin3:ixFisEmax3,idim1)=sFi%ws(ixFisEmin1:ixFisEmax1,&
          ixFisEmin2:ixFisEmax2,ixFisEmin3:ixFisEmax3,&
          idim1)*sFi%surfaceC(ixFisEmin1:ixFisEmax1,ixFisEmin2:ixFisEmax2,&
          ixFisEmin3:ixFisEmax3,idim1)
@@ -353,7 +352,7 @@ contains
 
       ! Fill coarse flux array from coarse field
       bfluxCo(ixCosEmin1:ixCosEmax1,ixCosEmin2:ixCosEmax2,&
-         ixCosEmin3:ixCosEmax3,idim1)=wCos(ixCosEmin1:ixCosEmax1,&
+         ixCosEmin3:ixCosEmax3,idim1)=sCo%ws(ixCosEmin1:ixCosEmax1,&
          ixCosEmin2:ixCosEmax2,ixCosEmin3:ixCosEmax3,&
          idim1)*sCo%surfaceC(ixCosEmin1:ixCosEmax1,ixCosEmin2:ixCosEmax2,&
          ixCosEmin3:ixCosEmax3,idim1)
@@ -745,36 +744,34 @@ contains
       ixFisCmin3=ixFimin3-kr(3,idim1);
       where(sFi%surfaceC(ixFisCmin1:ixFisCmax1,ixFisCmin2:ixFisCmax2,&
          ixFisCmin3:ixFisCmax3,idim1)/=zero)
-        wFis(ixFisCmin1:ixFisCmax1,ixFisCmin2:ixFisCmax2,ixFisCmin3:ixFisCmax3,&
+        sFi%ws(ixFisCmin1:ixFisCmax1,ixFisCmin2:ixFisCmax2,ixFisCmin3:ixFisCmax3,&
            idim1)=bfluxFi(ixFisCmin1:ixFisCmax1,ixFisCmin2:ixFisCmax2,&
            ixFisCmin3:ixFisCmax3,idim1)/sFi%surfaceC(ixFisCmin1:ixFisCmax1,&
            ixFisCmin2:ixFisCmax2,ixFisCmin3:ixFisCmax3,idim1)
       elsewhere
-        wFis(ixFisCmin1:ixFisCmax1,ixFisCmin2:ixFisCmax2,ixFisCmin3:ixFisCmax3,&
+        sFi%ws(ixFisCmin1:ixFisCmax1,ixFisCmin2:ixFisCmax2,ixFisCmin3:ixFisCmax3,&
            idim1)=zero
       end where
     end do
 
     if(phys_total_energy.and. .not.prolongprimitive) then
       B_energy_change(ixFimin1:ixFimax1,ixFimin2:ixFimax2,&
-         ixFimin3:ixFimax3)=0.5d0*sum(wFi(ixFimin1:ixFimax1,ixFimin2:ixFimax2,&
+         ixFimin3:ixFimax3)=0.5d0*sum(sFi%w(ixFimin1:ixFimax1,ixFimin2:ixFimax2,&
          ixFimin3:ixFimax3,iw_mag(:))**2,dim=ndim+1)
     end if
     call phys_face_to_center(ixFimin1,ixFimin2,ixFimin3,ixFimax1,ixFimax2,&
        ixFimax3,sFi)
     if(phys_total_energy.and. .not.prolongprimitive) then
       B_energy_change(ixFimin1:ixFimax1,ixFimin2:ixFimax2,&
-         ixFimin3:ixFimax3)=0.5d0*sum(wFi(ixFimin1:ixFimax1,ixFimin2:ixFimax2,&
+         ixFimin3:ixFimax3)=0.5d0*sum(sFi%w(ixFimin1:ixFimax1,ixFimin2:ixFimax2,&
          ixFimin3:ixFimax3,iw_mag(:))**2,&
          dim=ndim+1)-B_energy_change(ixFimin1:ixFimax1,ixFimin2:ixFimax2,&
          ixFimin3:ixFimax3)
-      wFi(ixFimin1:ixFimax1,ixFimin2:ixFimax2,ixFimin3:ixFimax3,&
-         iw_e)=wFi(ixFimin1:ixFimax1,ixFimin2:ixFimax2,ixFimin3:ixFimax3,&
+      sFi%w(ixFimin1:ixFimax1,ixFimin2:ixFimax2,ixFimin3:ixFimax3,&
+         iw_e)=sFi%w(ixFimin1:ixFimax1,ixFimin2:ixFimax2,ixFimin3:ixFimax3,&
          iw_e)+B_energy_change(ixFimin1:ixFimax1,ixFimin2:ixFimax2,&
          ixFimin3:ixFimax3)
     end if
-
-    end associate
 
     ! END NOONED
   end subroutine prolong_2nd_stg

--- a/src/amr/mod_coarsen.fpp
+++ b/src/amr/mod_coarsen.fpp
@@ -27,10 +27,6 @@ contains
     double precision :: B_energy_change(ixCoGmin1:ixCoGmax1,&
        ixCoGmin2:ixCoGmax2,ixCoGmin3:ixCoGmax3)
 
-    associate(wFi=>sFi%w(ixFiGmin1:ixFiGmax1,ixFiGmin2:ixFiGmax2,&
-       ixFiGmin3:ixFiGmax3,1:nw), wCo=>sCo%w(ixCoGmin1:ixCoGmax1,&
-       ixCoGmin2:ixCoGmax2,ixCoGmin3:ixCoGmax3,1:nw))
-    staggered: associate(wFis=>sFi%ws,wCos=>sCo%ws)
     ! coarsen by 2 in every direction - conservatively
 
 ! AGILE: tbd
@@ -46,10 +42,10 @@ contains
           do ixCo3 = ixComin3,ixComax3
              do ixCo2 = ixComin2,ixComax2
                 do ixCo1 = ixComin1,ixComax1
-                   ixFi3=2*(ixCo3-ixComin3)+ixFimin3
-                   ixFi2=2*(ixCo2-ixComin2)+ixFimin2
-                   ixFi1=2*(ixCo1-ixComin1)+ixFimin1
-                   wCo(ixCo1,ixCo2,ixCo3,iw)=sum(wFi(ixFi1:ixFi1+1,ixFi2:ixFi2+1,&
+                   ixFi3=2*(ixCo3-ixComin3)+ixFimin3+ixFiGmin3
+                   ixFi2=2*(ixCo2-ixComin2)+ixFimin2+ixFiGmin2
+                   ixFi1=2*(ixCo1-ixComin1)+ixFimin1+ixFiGmin1
+                   sCo%w(ixCo1+ixCoGmin1,ixCo2+ixCoGmin2,ixCo3+ixCoGmin3,iw)=sum(sFi%w(ixFi1:ixFi1+1,ixFi2:ixFi2+1,&
                         ixFi3:ixFi3+1,iw))*CoFiratio
                 end do
              end do
@@ -62,11 +58,11 @@ contains
           do ixCo3 = ixComin3,ixComax3
              do ixCo2 = ixComin2,ixComax2
                 do ixCo1 = ixComin1,ixComax1
-                   ixFi3=2*(ixCo3-ixComin3)+ixFimin3
-                   ixFi2=2*(ixCo2-ixComin2)+ixFimin2
-                   ixFi1=2*(ixCo1-ixComin1)+ixFimin1
-                   wCo(ixCo1,ixCo2,ixCo3,iw)= sum(sFi%dvolume(ixFi1:ixFi1+1,&
-                        ixFi2:ixFi2+1,ixFi3:ixFi3+1)*wFi(ixFi1:ixFi1+1,ixFi2:ixFi2+1,&
+                   ixFi3=2*(ixCo3-ixComin3)+ixFimin3+ixFiGmin3
+                   ixFi2=2*(ixCo2-ixComin2)+ixFimin2+ixFiGmin2
+                   ixFi1=2*(ixCo1-ixComin1)+ixFimin1+ixFiGmin1
+                   sCo%w(ixCo1+ixCoGmin1,ixCo2+ixCoGmin2,ixCo3+ixCoGmin3,iw)= sum(sFi%dvolume(ixFi1:ixFi1+1,&
+                        ixFi2:ixFi2+1,ixFi3:ixFi3+1)*sFi%w(ixFi1:ixFi1+1,ixFi2:ixFi2+1,&
                         ixFi3:ixFi3+1,iw)) /sCo%dvolume(ixCo1,ixCo2,ixCo3)
                 end do
              end do
@@ -87,13 +83,13 @@ contains
     !        ! This if statement catches the axis where surface is zero:
     !        if (sCo%surfaceC(ixCo1,ixCo2,ixCo3,iw)>1.0d-9*sCo%dvolume(ixCo1,&
     !           ixCo2,ixCo3)) then !Normal case
-    !          wCos(ixCo1,ixCo2,ixCo3,iw)=sum(sFi%surfaceC(ixFi1:ixFi1+1-kr(iw,&
+    !          sCo%w(ixCo1,ixCo2,ixCo3,iw)=sum(sFi%surfaceC(ixFi1:ixFi1+1-kr(iw,&
     !             1),ixFi2:ixFi2+1-kr(iw,2),ixFi3:ixFi3+1-kr(iw,3),&
-    !             iw)*wFis(ixFi1:ixFi1+1-kr(iw,1),ixFi2:ixFi2+1-kr(iw,2),&
+    !             iw)*sFi%ws(ixFi1:ixFi1+1-kr(iw,1),ixFi2:ixFi2+1-kr(iw,2),&
     !             ixFi3:ixFi3+1-kr(iw,3),iw)) /sCo%surfaceC(ixCo1,ixCo2,ixCo3,&
     !             iw)
     !        else ! On axis
-    !          wCos(ixCo1,ixCo2,ixCo3,iw)=zero
+    !          sCo%w(ixCo1,ixCo2,ixCo3,iw)=zero
     !        end if
     !     end do
     !     end do
@@ -125,8 +121,6 @@ contains
 !         ixCoGmax3,ixComin1,ixComin2,ixComin3,ixComax1,ixComax2,ixComax3,wCo,&
 !         sCo%x)
 !    end if
-    end associate staggered
-    end associate
   end subroutine coarsen_grid
 
 end module mod_coarsen

--- a/src/amr/mod_coarsen.fpp
+++ b/src/amr/mod_coarsen.fpp
@@ -42,10 +42,10 @@ contains
           do ixCo3 = ixComin3,ixComax3
              do ixCo2 = ixComin2,ixComax2
                 do ixCo1 = ixComin1,ixComax1
-                   ixFi3=2*(ixCo3-ixComin3)+ixFimin3+ixFiGmin3
-                   ixFi2=2*(ixCo2-ixComin2)+ixFimin2+ixFiGmin2
-                   ixFi1=2*(ixCo1-ixComin1)+ixFimin1+ixFiGmin1
-                   sCo%w(ixCo1+ixCoGmin1,ixCo2+ixCoGmin2,ixCo3+ixCoGmin3,iw)=sum(sFi%w(ixFi1:ixFi1+1,ixFi2:ixFi2+1,&
+                   ixFi3=2*(ixCo3-ixComin3)+ixFimin3+ixFiGmin3-1
+                   ixFi2=2*(ixCo2-ixComin2)+ixFimin2+ixFiGmin2-1
+                   ixFi1=2*(ixCo1-ixComin1)+ixFimin1+ixFiGmin1-1
+                   sCo%w(ixCo1+ixCoGmin1-1,ixCo2+ixCoGmin2-1,ixCo3+ixCoGmin3-1,iw)=sum(sFi%w(ixFi1:ixFi1+1,ixFi2:ixFi2+1,&
                         ixFi3:ixFi3+1,iw))*CoFiratio
                 end do
              end do
@@ -58,10 +58,10 @@ contains
           do ixCo3 = ixComin3,ixComax3
              do ixCo2 = ixComin2,ixComax2
                 do ixCo1 = ixComin1,ixComax1
-                   ixFi3=2*(ixCo3-ixComin3)+ixFimin3+ixFiGmin3
-                   ixFi2=2*(ixCo2-ixComin2)+ixFimin2+ixFiGmin2
-                   ixFi1=2*(ixCo1-ixComin1)+ixFimin1+ixFiGmin1
-                   sCo%w(ixCo1+ixCoGmin1,ixCo2+ixCoGmin2,ixCo3+ixCoGmin3,iw)= sum(sFi%dvolume(ixFi1:ixFi1+1,&
+                   ixFi3=2*(ixCo3-ixComin3)+ixFimin3+ixFiGmin3-1
+                   ixFi2=2*(ixCo2-ixComin2)+ixFimin2+ixFiGmin2-1
+                   ixFi1=2*(ixCo1-ixComin1)+ixFimin1+ixFiGmin1-1
+                   sCo%w(ixCo1+ixCoGmin1-1,ixCo2+ixCoGmin2-1,ixCo3+ixCoGmin3-1,iw)= sum(sFi%dvolume(ixFi1:ixFi1+1,&
                         ixFi2:ixFi2+1,ixFi3:ixFi3+1)*sFi%w(ixFi1:ixFi1+1,ixFi2:ixFi2+1,&
                         ixFi3:ixFi3+1,iw)) /sCo%dvolume(ixCo1,ixCo2,ixCo3)
                 end do

--- a/src/amr/mod_coarsen_refine.fpp
+++ b/src/amr/mod_coarsen_refine.fpp
@@ -13,9 +13,9 @@ module mod_coarsen_refine
   integer, dimension(:), allocatable :: recvrequest, sendrequest
   integer, dimension(:,:), allocatable :: recvstatus, sendstatus
   !> MPI buffers to send non-local coarsened grids
-  double precision, allocatable, dimension(:,:,:,:,:)  :: snd_buff, rcv_buff
-  integer, allocatable, dimension(:,:)  :: rcv_info
-  !$acc declare create(snd_buff,rcv_buff,rcv_info)
+  double precision, allocatable, dimension(:,:,:,:,:)  :: snd_buff_cf, rcv_buff_cf
+  integer, allocatable, dimension(:,:)  :: rcv_info_cf
+  !$acc declare create(snd_buff_cf,rcv_buff_cf,rcv_info_cf)
   !> maximum number of coarse blocks that can be sent after coarsening
   integer, parameter :: max_buff=1024
   !$acc declare copyin(max_buff)
@@ -81,11 +81,11 @@ contains
     end if
 
     ! Allocate the send and receive buffers
-    if ( .not. allocated(snd_buff) ) then
-       allocate( snd_buff(block_nx1/2, block_nx2/2, block_nx3/2, nw, max_buff), &
-            rcv_buff(block_nx1/2, block_nx2/2, block_nx3/2, nw, max_buff), &
-            rcv_info(4, max_buff) )
-       !$acc update device(snd_buff, rcv_buff, rcv_info)
+    if ( .not. allocated(snd_buff_cf) ) then
+       allocate( snd_buff_cf(block_nx1/2, block_nx2/2, block_nx3/2, nw, max_buff), &
+            rcv_buff_cf(block_nx1/2, block_nx2/2, block_nx3/2, nw, max_buff), &
+            rcv_info_cf(4, max_buff) )
+       !$acc update device(snd_buff_cf, rcv_buff_cf, rcv_info_cf)
     end if
 
     do ipe=0,npe-1
@@ -139,16 +139,16 @@ contains
 
     ! unpack the receive buffers on GPU
 #ifdef NOGPUDIRECT
-    !$acc update device(rcv_buff(:,:,:,:,1:irecv))
+    !$acc update device(rcv_buff_cf(:,:,:,:,1:irecv))
 #endif
-    !$acc update device(rcv_info(:,1:irecv))
+    !$acc update device(rcv_info_cf(:,1:irecv))
 
     !$acc parallel loop gang
     do ibuff = 1, irecv
-       igrid = rcv_info(1,ibuff)
-       ic1   = rcv_info(2,ibuff)
-       ic2   = rcv_info(3,ibuff)
-       ic3   = rcv_info(4,ibuff)
+       igrid = rcv_info_cf(1,ibuff)
+       ic1   = rcv_info_cf(2,ibuff)
+       ic2   = rcv_info_cf(3,ibuff)
+       ic3   = rcv_info_cf(4,ibuff)
        !$acc loop collapse(4) vector
        do iw = 1, nw
           do ix3 = 1, block_nx3/2
@@ -159,7 +159,7 @@ contains
                         ixMlo2-1+(ic2-1)*block_nx2/2 + ix2, &
                         ixMlo3-1+(ic3-1)*block_nx3/2 + ix3, &
                         iw) &
-                        = rcv_buff(ix1, ix2, ix3, iw, ibuff)
+                        = rcv_buff_cf(ix1, ix2, ix3, iw, ibuff)
                 end do
              end do
           end do
@@ -507,7 +507,7 @@ contains
                       do ix3 = 1, block_nx3/2
                          do ix2 = 1, block_nx2/2
                             do ix1 = 1, block_nx1/2
-                               snd_buff(ix1, ix2, ix3, iw, isend) = &
+                               snd_buff_cf(ix1, ix2, ix3, iw, isend) = &
                                     psc(igridFi)%w(ixCoMmin1-1+ix1, ixCoMmin2-1+ix2, ixCoMmin3-1+ix3, iw)
                             end do
                          end do
@@ -515,11 +515,11 @@ contains
                    end do
 
 #ifndef NOGPUDIRECT
-                   !$acc host_data use_device(snd_buff)
+                   !$acc host_data use_device(snd_buff_cf)
 #else
-                   !$acc update host(snd_buff(:,:,:,:,isend))
+                   !$acc update host(snd_buff_cf(:,:,:,:,isend))
 #endif
-                   call mpi_isend_wrapper(snd_buff(:,:,:,:,isend), &
+                   call mpi_isend_wrapper(snd_buff_cf(:,:,:,:,isend), &
                         block_nx1*block_nx2*block_nx3/8*nw,MPI_DOUBLE_PRECISION,ipe,itag, icomm,&
                         sendrequest(isend),ierrmpi)
 #ifndef NOGPUDIRECT
@@ -542,15 +542,15 @@ contains
                       call mpistop('coarsen_grid_siblings: max_buff too small in receive')
                    end if
 #ifndef NOGPUDIRECT
-                   !$acc host_data use_device(rcv_buff)
+                   !$acc host_data use_device(rcv_buff_cf)
 #endif
-                   call mpi_irecv_wrapper(rcv_buff(:,:,:,:,irecv), &
+                   call mpi_irecv_wrapper(rcv_buff_cf(:,:,:,:,irecv), &
                         block_nx1*block_nx2*block_nx3/8*nw,MPI_DOUBLE_PRECISION,ipeFi, &
                         itag, icomm,recvrequest(irecv),ierrmpi)
 #ifndef NOGPUDIRECT
                    !$acc end host_data
 #endif
-                   rcv_info(:,irecv) = [igrid, ic1, ic2, ic3]
+                   rcv_info_cf(:,irecv) = [igrid, ic1, ic2, ic3]
                    if(stagger_grid) then
                       do idir=1,ndim
                          itag_stg=(npe+ipeFi+1)+igridFi*(ndir-1+idir)

--- a/src/amr/mod_errest.fpp
+++ b/src/amr/mod_errest.fpp
@@ -53,8 +53,6 @@ contains
     logical                            :: refineflag, coarsenflag
     double precision, parameter        :: epsilon=1.0d-6
 
-    associate(w => bg(1)%w(:,:,:,:, igrid))
-
       level       = node(plevel_,igrid)
       threshold   = refine_threshold(level)
 
@@ -78,47 +76,46 @@ contains
 
                         numerator = numerator + &
                              ( &
-                             ( w(ix1+kr(1,idims2)+kr(1,idims1), &
+                             ( bg(1)%w(ix1+kr(1,idims2)+kr(1,idims1), &
                              ix2+kr(2,idims2)+kr(2,idims1), &
-                             ix3+kr(3,idims2)+kr(3,idims1), iflag)    &
-                             - w(ix1-kr(1,idims2)+kr(1,idims1), &
+                             ix3+kr(3,idims2)+kr(3,idims1), iflag, igrid)    &
+                             - bg(1)%w(ix1-kr(1,idims2)+kr(1,idims1), &
                              ix2-kr(2,idims2)+kr(2,idims1), &
-                             ix3-kr(3,idims2)+kr(3,idims1), iflag) )  &
+                             ix3-kr(3,idims2)+kr(3,idims1), iflag, igrid) )  &
                              - &
-                             ( w(ix1+kr(1,idims2)-kr(1,idims1), &
+                             ( bg(1)%w(ix1+kr(1,idims2)-kr(1,idims1), &
                              ix2+kr(2,idims2)-kr(2,idims1), &
-                             ix3+kr(3,idims2)-kr(3,idims1), iflag)    &
-                             - w(ix1-kr(1,idims2)-kr(1,idims1), &
+                             ix3+kr(3,idims2)-kr(3,idims1), iflag, igrid)    &
+                             - bg(1)%w(ix1-kr(1,idims2)-kr(1,idims1), &
                              ix2-kr(2,idims2)-kr(2,idims1), &
-                             ix3-kr(3,idims2)-kr(3,idims1), iflag) )  &
+                             ix3-kr(3,idims2)-kr(3,idims1), iflag, igrid) )  &
                              )**2
 
                         denominator = denominator + &
                              ( &
                              abs( &
-                             w(ix1+2*kr(1,idims1), ix2+2*kr(2,idims1), ix3+2*kr(3,idims1), iflag) &
-                             - w(ix1, ix2, ix3, iflag) &
+                             bg(1)%w(ix1+2*kr(1,idims1), ix2+2*kr(2,idims1), ix3+2*kr(3,idims1), iflag, igrid) &
+                             - bg(1)%w(ix1, ix2, ix3, iflag, igrid) &
                              ) &
                              + abs( &
-                             w(ix1, ix2, ix3, iflag) &
-                             - w(ix1-2*kr(1,idims1), ix2-2*kr(2,idims1), ix3-2*kr(3,idims1), iflag) &
+                             bg(1)%w(ix1, ix2, ix3, iflag, igrid) &
+                             - bg(1)%w(ix1-2*kr(1,idims1), ix2-2*kr(2,idims1), ix3-2*kr(3,idims1), iflag, igrid) &
                              ) &
                              + amr_wavefilter(level) * ( &
-                             ( abs( w(ix1+kr(1,idims1)+kr(1,idims2), &
+                             ( abs( bg(1)%w(ix1+kr(1,idims1)+kr(1,idims2), &
                              ix2+kr(2,idims1)+kr(2,idims2), &
-                             ix3+kr(3,idims1)+kr(3,idims2), iflag) )   &
-                             + abs( w(ix1-kr(1,idims1)+kr(1,idims2), &
-                             ix2-kr(2,idims1)+kr(2,idims2), ix3-kr(3,idims1)+kr(3,idims2), iflag) ) ) &
+                             ix3+kr(3,idims1)+kr(3,idims2), iflag, igrid) )   &
+                             + abs( bg(1)%w(ix1-kr(1,idims1)+kr(1,idims2), &
+                             ix2-kr(2,idims1)+kr(2,idims2), ix3-kr(3,idims1)+kr(3,idims2), iflag, igrid) ) ) &
                              + &
-                             ( abs( w(ix1+kr(1,idims1)-kr(1,idims2), &
+                             ( abs( bg(1)%w(ix1+kr(1,idims1)-kr(1,idims2), &
                              ix2+kr(2,idims1)-kr(2,idims2), &
-                             ix3+kr(3,idims1)-kr(3,idims2), iflag) )   &
-                             + abs( w(ix1-kr(1,idims1)-kr(1,idims2), &
+                             ix3+kr(3,idims1)-kr(3,idims2), iflag, igrid) )   &
+                             + abs( bg(1)%w(ix1-kr(1,idims1)-kr(1,idims2), &
                              ix2-kr(2,idims1)-kr(2,idims2), &
-                             ix3-kr(3,idims1)-kr(3,idims2), iflag) ) ) &
+                             ix3-kr(3,idims1)-kr(3,idims2), iflag, igrid) ) ) &
                              ) &
                              )**2
-
                      end do
                   end do
 
@@ -140,7 +137,6 @@ contains
       if (refineflag .and. level < refine_max_level) refine(igrid,mype)=.true.
       if (coarsenflag .and. level > 1) coarsen(igrid,mype)=.true.
 
-    end associate
   end subroutine lohner_grid
 
   subroutine forcedrefine_grid(igrid)

--- a/src/amr/mod_load_balance.fpp
+++ b/src/amr/mod_load_balance.fpp
@@ -8,12 +8,12 @@ module mod_load_balance
   implicit none
 
   !> MPI buffers to send blocks
-  double precision, allocatable, dimension(:,:,:,:,:)  :: snd_buff, rcv_buff
-  integer, allocatable, dimension(:)  :: rcv_info
-  !$acc declare create(snd_buff,rcv_buff,rcv_info)
+  double precision, allocatable, dimension(:,:,:,:,:)  :: snd_buff_lb, rcv_buff_lb
+  integer, allocatable, dimension(:)  :: rcv_info_lb
+  !$acc declare create(snd_buff_lb,rcv_buff_lb,rcv_info_lb)
   !> maximum number of blocks to send
   integer, parameter :: max_buff=1024
-  private :: snd_buff, rcv_buff, max_buff,rcv_info
+  private :: snd_buff_lb, rcv_buff_lb, max_buff,rcv_info_lb
 
 contains
   !> reallocate blocks into processors for load balance
@@ -61,11 +61,11 @@ contains
     end if
 
     ! Allocate the send and receive buffers
-    if ( .not. allocated(snd_buff) ) then
-       allocate( snd_buff(block_nx1, block_nx2, block_nx3, nw, max_buff), &
-            rcv_buff(block_nx1, block_nx2, block_nx3, nw, max_buff), &
-            rcv_info(max_buff) )
-       !$acc update device(snd_buff, rcv_buff, rcv_info)
+    if ( .not. allocated(snd_buff_lb) ) then
+       allocate( snd_buff_lb(block_nx1, block_nx2, block_nx3, nw, max_buff), &
+            rcv_buff_lb(block_nx1, block_nx2, block_nx3, nw, max_buff), &
+            rcv_info_lb(max_buff) )
+       !$acc update device(snd_buff_lb, rcv_buff_lb, rcv_info_lb)
     end if
 
     do ipe=0,npe-1; do Morton_no=Morton_start(ipe),Morton_stop(ipe)
@@ -106,19 +106,19 @@ contains
 
     ! unpack the receive buffers on GPU
 #ifdef NOGPUDIRECT
-   !$acc update device(rcv_buff(:,:,:,:,1:irecv))
+   !$acc update device(rcv_buff_lb(:,:,:,:,1:irecv))
 #endif
-    !$acc update device(rcv_info(1:irecv))
+    !$acc update device(rcv_info_lb(1:irecv))
     !$acc parallel loop gang
     do ibuff = 1, irecv
-       recv_igrid = rcv_info(ibuff)
+       recv_igrid = rcv_info_lb(ibuff)
        !$acc loop collapse(4) vector
        do iw = 1, nw
           do ix3 = 1, block_nx3
              do ix2 = 1, block_nx2
                 do ix1 = 1, block_nx1
                    bg(1)%w(ixMlo1-1 + ix1, ixMlo2-1 + ix2, ixMlo3-1 + ix3, iw, recv_igrid) &
-                        = rcv_buff(ix1, ix2, ix3, iw, ibuff)
+                        = rcv_buff_lb(ix1, ix2, ix3, iw, ibuff)
                 end do
              end do
           end do
@@ -159,16 +159,16 @@ contains
            call mpistop('load_balance: max_buff too small in receive')
         end if
 #ifndef NOGPUDIRECT
-        !$acc host_data use_device(rcv_buff)
+        !$acc host_data use_device(rcv_buff_lb)
 #endif
-        call mpi_irecv_wrapper(rcv_buff(:,:,:,:,irecv), &
+        call mpi_irecv_wrapper(rcv_buff_lb(:,:,:,:,irecv), &
                         block_nx1*block_nx2*block_nx3*nw, MPI_DOUBLE_PRECISION, &
              send_ipe,itag, icomm, &
              recvrequest(irecv),ierrmpi)
 #ifndef NOGPUDIRECT
         !$acc end host_data
 #endif
-        rcv_info(irecv) = recv_igrid
+        rcv_info_lb(irecv) = recv_igrid
         if(stagger_grid) then
            itag=recv_igrid+max_blocks
            call mpi_irecv_wrapper(ps(recv_igrid)%ws,1,type_block_io_stg,send_ipe,itag,&
@@ -190,7 +190,7 @@ contains
            do ix3 = 1, block_nx3
               do ix2 = 1, block_nx2
                  do ix1 = 1, block_nx1
-                    snd_buff(ix1, ix2, ix3, iw, isend) = &
+                    snd_buff_lb(ix1, ix2, ix3, iw, isend) = &
                          bg(1)%w(ixMlo1-1+ix1, ixMlo2-1+ix2, ixMlo3-1+ix3, iw, send_igrid)
                  end do
               end do
@@ -198,11 +198,11 @@ contains
         end do
 
 #ifndef NOGPUDIRECT
-        !$acc host_data use_device(snd_buff)
+        !$acc host_data use_device(snd_buff_lb)
 #else
-        !$acc update host(snd_buff(:,:,:,:,isend))
+        !$acc update host(snd_buff_lb(:,:,:,:,isend))
 #endif
-        call mpi_isend_wrapper(snd_buff(:,:,:,:,isend), &
+        call mpi_isend_wrapper(snd_buff_lb(:,:,:,:,isend), &
                         block_nx1*block_nx2*block_nx3*nw, MPI_DOUBLE_PRECISION, &
              recv_ipe,itag, icomm, &
              sendrequest(isend),ierrmpi)

--- a/src/amr/mod_load_balance.fpp
+++ b/src/amr/mod_load_balance.fpp
@@ -6,14 +6,21 @@ module mod_load_balance
 #define mpi_isend_wrapper MPI_ISEND
 #endif
   implicit none
-
+  private
+  !> MPI recv send variables for AMR
+  integer :: itag, irecv, isend
+  integer :: recv_igrid, recv_ipe, send_igrid, send_ipe, igrid
+  integer, dimension(:), allocatable :: recvrequest, sendrequest
+  !> MPI recv send variables for staggered-variable AMR
+  integer, dimension(:), allocatable :: recvrequest_stg, sendrequest_stg
   !> MPI buffers to send blocks
   double precision, allocatable, dimension(:,:,:,:,:)  :: snd_buff_lb, rcv_buff_lb
   integer, allocatable, dimension(:)  :: rcv_info_lb
   !$acc declare create(snd_buff_lb,rcv_buff_lb,rcv_info_lb)
   !> maximum number of blocks to send
   integer, parameter :: max_buff=1024
-  private :: snd_buff_lb, rcv_buff_lb, max_buff,rcv_info_lb
+
+  public :: load_balance
 
 contains
   !> reallocate blocks into processors for load balance
@@ -23,17 +30,12 @@ contains
     use mod_space_filling_curve
     use mod_amr_solution_node, only: getnode,putnode
     use mod_functions_forest, only: change_ipe_tree_leaf
-    use mod_comm_lib, only: mpistop
 
-    integer :: Morton_no, recv_igrid, recv_ipe, send_igrid, send_ipe, igrid,&
-        ipe
+    integer :: Morton_no, ipe
     !> MPI recv send variables for AMR
-    integer :: itag, irecv, isend
-    integer, dimension(:), allocatable :: recvrequest, sendrequest
     integer, dimension(:,:), allocatable :: recvstatus, sendstatus
     !> MPI recv send variables for staggered-variable AMR
     integer :: itag_stg
-    integer, dimension(:), allocatable :: recvrequest_stg, sendrequest_stg
     integer, dimension(:,:), allocatable :: recvstatus_stg, sendstatus_stg
     integer :: ix1, ix2, ix3, iw, ibuff
 
@@ -146,77 +148,78 @@ contains
     ! Update sfc array: igrid and ipe info in space filling curve
     call amr_Morton_order()
 
-    contains
-
-      subroutine lb_recv
-        use mod_amr_solution_node, only: alloc_node
-
-        call alloc_node(recv_igrid)
-
-        itag=recv_igrid
-        irecv=irecv+1
-        if (irecv > max_buff) then
-           call mpistop('load_balance: max_buff too small in receive')
-        end if
-#ifndef NOGPUDIRECT
-        !$acc host_data use_device(rcv_buff_lb)
-#endif
-        call mpi_irecv_wrapper(rcv_buff_lb(:,:,:,:,irecv), &
-                        block_nx1*block_nx2*block_nx3*nw, MPI_DOUBLE_PRECISION, &
-             send_ipe,itag, icomm, &
-             recvrequest(irecv),ierrmpi)
-#ifndef NOGPUDIRECT
-        !$acc end host_data
-#endif
-        rcv_info_lb(irecv) = recv_igrid
-        if(stagger_grid) then
-           itag=recv_igrid+max_blocks
-           call mpi_irecv_wrapper(ps(recv_igrid)%ws,1,type_block_io_stg,send_ipe,itag,&
-                icomm,recvrequest_stg(irecv),ierrmpi)
-        end if
-
-      end subroutine lb_recv
-
-      subroutine lb_send
-
-        itag=recv_igrid
-        isend=isend+1
-        if (isend > max_buff) then
-           call mpistop('load_balance: max_buff too small in send')
-        end if
-        !$acc parallel loop gang
-        do iw = 1, nw
-           !$acc loop collapse(3) vector
-           do ix3 = 1, block_nx3
-              do ix2 = 1, block_nx2
-                 do ix1 = 1, block_nx1
-                    snd_buff_lb(ix1, ix2, ix3, iw, isend) = &
-                         bg(1)%w(ixMlo1-1+ix1, ixMlo2-1+ix2, ixMlo3-1+ix3, iw, send_igrid)
-                 end do
-              end do
-           end do
-        end do
-
-#ifndef NOGPUDIRECT
-        !$acc host_data use_device(snd_buff_lb)
-#else
-        !$acc update host(snd_buff_lb(:,:,:,:,isend))
-#endif
-        call mpi_isend_wrapper(snd_buff_lb(:,:,:,:,isend), &
-                        block_nx1*block_nx2*block_nx3*nw, MPI_DOUBLE_PRECISION, &
-             recv_ipe,itag, icomm, &
-             sendrequest(isend),ierrmpi)
-#ifndef NOGPUDIRECT
-        !$acc end host_data
-#endif
-        if(stagger_grid) then
-           itag=recv_igrid+max_blocks
-           call mpi_isend_wrapper(ps(send_igrid)%ws,1,type_block_io_stg,recv_ipe,itag,&
-                icomm,sendrequest_stg(isend),ierrmpi)
-        end if
-
-      end subroutine lb_send
-
   end subroutine load_balance
+
+  subroutine lb_recv
+    use mod_global_parameters
+    use mod_amr_solution_node, only: alloc_node
+    use mod_comm_lib, only: mpistop
+
+    call alloc_node(recv_igrid)
+
+    itag=recv_igrid
+    irecv=irecv+1
+    if (irecv > max_buff) then
+       call mpistop('load_balance: max_buff too small in receive')
+    end if
+#ifndef NOGPUDIRECT
+    !$acc host_data use_device(rcv_buff_lb)
+#endif
+    call mpi_irecv_wrapper(rcv_buff_lb(:,:,:,:,irecv), &
+                   block_nx1*block_nx2*block_nx3*nw, MPI_DOUBLE_PRECISION, &
+          send_ipe,itag, icomm, &
+          recvrequest(irecv),ierrmpi)
+#ifndef NOGPUDIRECT
+    !$acc end host_data
+#endif
+    rcv_info_lb(irecv) = recv_igrid
+    if(stagger_grid) then
+       itag=recv_igrid+max_blocks
+       call mpi_irecv_wrapper(ps(recv_igrid)%ws,1,type_block_io_stg,send_ipe,itag,&
+             icomm,recvrequest_stg(irecv),ierrmpi)
+    end if
+  end subroutine lb_recv
+
+  subroutine lb_send
+    use mod_global_parameters
+    use mod_comm_lib, only: mpistop
+
+    integer :: ix1, ix2, ix3, iw, ibuff
+
+    itag=recv_igrid
+    isend=isend+1
+    if (isend > max_buff) then
+       call mpistop('load_balance: max_buff too small in send')
+    end if
+    !$acc parallel loop gang default(present)
+    do iw = 1, nw
+       !$acc loop collapse(3) vector
+       do ix3 = 1, block_nx3
+          do ix2 = 1, block_nx2
+             do ix1 = 1, block_nx1
+                snd_buff_lb(ix1, ix2, ix3, iw, isend) = &
+                      bg(1)%w(ixMlo1-1+ix1, ixMlo2-1+ix2, ixMlo3-1+ix3, iw, send_igrid)
+             end do
+          end do
+       end do
+    end do
+
+#ifndef NOGPUDIRECT
+    !$acc host_data use_device(snd_buff_lb)
+#else
+    !$acc update host(snd_buff_lb(:,:,:,:,isend))
+#endif
+    call mpi_isend_wrapper(snd_buff_lb(:,:,:,:,isend), &
+                   block_nx1*block_nx2*block_nx3*nw, MPI_DOUBLE_PRECISION, &
+          recv_ipe,itag, icomm, sendrequest(isend),ierrmpi)
+#ifndef NOGPUDIRECT
+    !$acc end host_data
+#endif
+    if(stagger_grid) then
+       itag=recv_igrid+max_blocks
+       call mpi_isend_wrapper(ps(send_igrid)%ws,1,type_block_io_stg,recv_ipe,itag,&
+             icomm,sendrequest_stg(isend),ierrmpi)
+    end if
+  end subroutine lb_send
 
 end module mod_load_balance

--- a/src/amr/mod_refine.fpp
+++ b/src/amr/mod_refine.fpp
@@ -2,9 +2,9 @@ module mod_refine
 
   implicit none
   private
- 
+
   public :: refine_grids
- 
+
 contains
 
 
@@ -13,11 +13,11 @@ contains
     use mod_global_parameters
     use mod_initialize_amr, only: initial_condition
     use mod_amr_solution_node, only: alloc_node, dealloc_node
-  
+
     integer, dimension(2,2,2), intent(in) :: child_igrid, child_ipe
     integer, intent(in) :: igrid, ipe
     logical, intent(in) :: active
-  
+
     integer :: ic1,ic2,ic3
 
     ! allocate solution space for new children
@@ -42,41 +42,41 @@ contains
        end do
        end do
     end if
-  
+
     ! remove solution space of igrid to save memory when converting data
     if(convert) call dealloc_node(igrid)
   end subroutine refine_grids
-  
+
   !> prolong one block
   subroutine prolong_grid(child_igrid,child_ipe,igrid,ipe)
     use mod_physics, only: phys_to_primitive, phys_to_conserved
     use mod_global_parameters
     use mod_amr_fct, only: old_neighbors
-  
+
     integer, dimension(2,2,2), intent(in) :: child_igrid, child_ipe
     integer, intent(in) :: igrid, ipe
-  
+
     integer :: ixmin1,ixmin2,ixmin3,ixmax1,ixmax2,ixmax3, ichild, ixComin1,&
        ixComin2,ixComin3,ixComax1,ixComax2,ixComax3, ic1,ic2,ic3
     double precision :: dxCo1,dxCo2,dxCo3, xComin1,xComin2,xComin3, dxFi1,&
        dxFi2,dxFi3, xFimin1,xFimin2,xFimin3
-  
+
     ixmin1=ixMlo1-1;ixmin2=ixMlo2-1;ixmin3=ixMlo3-1;ixmax1=ixMhi1+1
     ixmax2=ixMhi2+1;ixmax3=ixMhi3+1;
-  
+
     if(prolongprimitive) call phys_to_primitive(ixGlo1,ixGlo2,ixGlo3,ixGhi1,&
        ixGhi2,ixGhi3,ixmin1,ixmin2,ixmin3,ixmax1,ixmax2,ixmax3,ps(igrid)%w,&
        ps(igrid)%x)
-  
+
     xComin1=rnode(rpxmin1_,igrid)
     xComin2=rnode(rpxmin2_,igrid)
     xComin3=rnode(rpxmin3_,igrid)
     dxCo1=rnode(rpdx1_,igrid)
     dxCo2=rnode(rpdx2_,igrid)
     dxCo3=rnode(rpdx3_,igrid)
-  
+
     if(stagger_grid) call old_neighbors(child_igrid,child_ipe,igrid,ipe)
-    
+
     do ic3=1,2
        do ic2=1,2
           do ic1=1,2
@@ -107,9 +107,9 @@ contains
     if (prolongprimitive) call phys_to_conserved(ixGlo1,ixGlo2,ixGlo3,ixGhi1,&
        ixGhi2,ixGhi3,ixmin1,ixmin2,ixmin3,ixmax1,ixmax2,ixmax3,ps(igrid)%w,&
        ps(igrid)%x)
-  
+
   end subroutine prolong_grid
-  
+
   !> do 2nd order prolongation
   subroutine prolong_2nd(sCo,ixComin1,ixComin2,ixComin3,ixComax1,ixComax2,&
      ixComax3,sFi,dxCo1,dxCo2,dxCo3,xComin1,xComin2,xComin3,dxFi1,dxFi2,dxFi3,&
@@ -117,14 +117,14 @@ contains
     use mod_physics, only: phys_to_conserved, phys_handle_small_values
     use mod_global_parameters
     use mod_amr_fct, only: already_fine, prolong_2nd_stg
-  
+
     integer, intent(in) :: ixComin1,ixComin2,ixComin3,ixComax1,ixComax2,&
        ixComax3, igridFi, igridCo
     double precision, intent(in) :: dxCo1,dxCo2,dxCo3, xComin1,xComin2,xComin3,&
         dxFi1,dxFi2,dxFi3, xFimin1,xFimin2,xFimin3
     type(state), intent(in)      :: sCo
     type(state), intent(inout)   :: sFi
-  
+
     integer :: ixCo1,ixCo2,ixCo3, jxCo1,jxCo2,jxCo3, hxCo1,hxCo2,hxCo3, ixFi1,&
        ixFi2,ixFi3, ix1,ix2,ix3, idim, iw, ixCgmin1,ixCgmin2,ixCgmin3,ixCgmax1,&
        ixCgmax2,ixCgmax3, el
@@ -132,8 +132,7 @@ contains
     double precision :: slope(nw,ndim)
     double precision :: eta1,eta2,eta3
     logical :: fine_min1,fine_min2,fine_min3,fine_max1,fine_max2,fine_max3
-  
-    associate(wCo=>sCo%w, wFi=>sFi%w)
+
     ixCgmin1=ixComin1;ixCgmin2=ixComin2;ixCgmin3=ixComin3;ixCgmax1=ixComax1
     ixCgmax2=ixComax2;ixCgmax3=ixComax3;
 
@@ -185,9 +184,9 @@ contains
              end do
              ! cell-centered coordinates of coarse grid point
              !^D&xCo^D=xCo({ixCo^DD},^D)
-             do ix3=ixFi3,ixFi3+1 
-                do ix2=ixFi2,ixFi2+1 
-                   do ix1=ixFi1,ixFi1+1 
+             do ix3=ixFi3,ixFi3+1
+                do ix2=ixFi2,ixFi2+1
+                   do ix1=ixFi1,ixFi1+1
                       ! cell-centered coordinates of fine grid point
                       !^D&xFi^D=xFi({ix^DD},^D)
                       if(slab_uniform) then
@@ -202,13 +201,13 @@ contains
                       else
                          ! forefactor is -0.5d0 when ix=ixFi and +0.5d0 for ixFi+1
                          eta1=(dble(ix1-ixFi1)-0.5d0)*(one-sFi%dvolume(ix1,ix2,&
-                              ix3) /sum(sFi%dvolume(ixFi1:ixFi1+1,ix2,ix3)))  
+                              ix3) /sum(sFi%dvolume(ixFi1:ixFi1+1,ix2,ix3)))
                          ! forefactor is -0.5d0 when ix=ixFi and +0.5d0 for ixFi+1
                          eta2=(dble(ix2-ixFi2)-0.5d0)*(one-sFi%dvolume(ix1,ix2,&
-                              ix3) /sum(sFi%dvolume(ix1,ixFi2:ixFi2+1,ix3)))  
+                              ix3) /sum(sFi%dvolume(ix1,ixFi2:ixFi2+1,ix3)))
                          ! forefactor is -0.5d0 when ix=ixFi and +0.5d0 for ixFi+1
                          eta3=(dble(ix3-ixFi3)-0.5d0)*(one-sFi%dvolume(ix1,ix2,&
-                              ix3) /sum(sFi%dvolume(ix1,ix2,ixFi3:ixFi3+1)))  
+                              ix3) /sum(sFi%dvolume(ix1,ix2,ixFi3:ixFi3+1)))
                       end if
                       bg(1)%w(ix1,ix2,ix3,1:nw, igridFi) = bg(1)%w(ixCo1,ixCo2,ixCo3,1:nw, igridCo) + (slope(1:nw,&
                            1)*eta1)+(slope(1:nw,2)*eta2)+(slope(1:nw,3)*eta3)
@@ -228,20 +227,19 @@ contains
             fine_max3)
     end if
 
-    if(fix_small_values) call phys_handle_small_values(prolongprimitive,wFi,&
+    if(fix_small_values) call phys_handle_small_values(prolongprimitive,sFi%w,&
          sFi%x,ixGlo1,ixGlo2,ixGlo3,ixGhi1,ixGhi2,ixGhi3,ixMlo1,ixMlo2,ixMlo3,&
          ixMhi1,ixMhi2,ixMhi3,'prolong_2nd')
     if(prolongprimitive) call phys_to_conserved(ixGlo1,ixGlo2,ixGlo3,ixGhi1,&
-         ixGhi2,ixGhi3,ixMlo1,ixMlo2,ixMlo3,ixMhi1,ixMhi2,ixMhi3,wFi,sFi%x)
-  end associate
+         ixGhi2,ixGhi3,ixMlo1,ixMlo2,ixMlo3,ixMhi1,ixMhi2,ixMhi3,sFi%w,sFi%x)
 
   end subroutine prolong_2nd
-  
+
   !> do 1st order prolongation
   subroutine prolong_1st(wCo,ixComin1,ixComin2,ixComin3,ixComax1,ixComax2,&
        ixComax3,wFi,xFi)
     use mod_global_parameters
-  
+
     integer, intent(in) :: ixComin1,ixComin2,ixComin3,ixComax1,ixComax2,&
        ixComax3
     double precision, intent(in) :: wCo(ixGlo1:ixGhi1,ixGlo2:ixGhi2,&
@@ -249,7 +247,7 @@ contains
        1:ndim)
     double precision, intent(out) :: wFi(ixGlo1:ixGhi1,ixGlo2:ixGhi2,&
        ixGlo3:ixGhi3,nw)
-  
+
     integer :: ixCo1,ixCo2,ixCo3, ixFi1,ixFi2,ixFi3, iw
     integer :: ixFimin1,ixFimin2,ixFimin3,ixFimax1,ixFimax2,ixFimax3
 


### PR DESCRIPTION
* Remove some `associate`statements
* Restructured `contained` subroutines (just to be safe, this should not strictly be required)
* Work around a very strange OpenACC bug: private module-level variables in two different modules alias to the same GPU memory with Cray. Cray says this is ok according to the OpenACC spec. Indeed the spec only mentions a subroutine-level and programme-level namespace, although the aliasing behaviour does seem to conflict with the Fortran standard...

With these changes, multi-GPU AMR now works on LUMI.