### PR TITLE
Create workflow for self-hosted GPU runner

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Python 3.8
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -27,21 +27,21 @@ jobs:
       - name: list GPUs
         run: nvidia-smi
 
-      - name: create Python environment
-        run: |
-          python3.13 -m pip install uv
-          uv sync
-
       - name: check compiler versions
         run: |
           mpirun --version
           nvfortran --version
+
+      - name: create Python environment
+        run: |
+          python3.13 -m pip install uv
+          uv sync
 
       - name: compile and run tests
         run: |
           #cd tests
           #NUM_PROCS=2 ARCH=nvidia OPENACC=1 ./test_runner.sh
           # Single test for now - just to see if it runs
-          cd test/hd/KH3D
+          cd tests/hd/KH3D
           make arch=nvidia OPENACC=1 
           mpirun -n 2 ./amrvac -i test.par

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -1,0 +1,36 @@
+name: gpu
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  nvidia:
+    name: NVIDIA GPU
+    env:
+      AMRVAC_DIR: ${{ github.workspace }}
+      
+    runs-on: self-hosted
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: check compiler versions
+        run: |
+          nvfortran --version
+          mpirun --version
+      - name: create Python environment
+        run: |
+          pip install uv
+          uv sync
+      - name: compile and run tests
+        run: |
+          #cd tests
+          #NUM_PROCS=2 ARCH=nvidia OPENACC=1 ./test_runner.sh
+          # Single test for now - just to see if it runs
+          cd test/hd/KH3D
+          make arch=nvidia OPENACC=1 
+          mpirun -n 2 ./amrvac -i test.par

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -43,5 +43,6 @@ jobs:
           #NUM_PROCS=2 ARCH=nvidia OPENACC=1 ./test_runner.sh
           # Single test for now - just to see if it runs
           cd tests/hd/KH3D
+          source $AMRVAC_DIR/.venv/bin/activate
           make arch=nvidia OPENACC=1 
           mpirun -n 2 ./amrvac -i test.par

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -16,16 +16,27 @@ jobs:
     runs-on: self-hosted
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
+
+      - name: set paths
+        run: |
+          echo "/volume1/scratch/shared_software/openmpi-nvhpc-5.0.8/bin" >> "$GITHUB_PATH"
+          echo "/volume1/scratch/shared_software/nvhpc/hpc_sdk/Linux_x86_64/25.11/compilers/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: list GPUs
+        run: nvidia-smi
+
+      - name: create Python environment
+        run: |
+          python3.13 -m pip install uv
+          uv sync
 
       - name: check compiler versions
         run: |
-          nvfortran --version
           mpirun --version
-      - name: create Python environment
-        run: |
-          pip install uv
-          uv sync
+          nvfortran --version
+
       - name: compile and run tests
         run: |
           #cd tests

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -45,4 +45,5 @@ jobs:
           cd tests/hd/KH3D
           source $AMRVAC_DIR/.venv/bin/activate
           make arch=nvidia OPENACC=1 
+          ldd amrvac
           mpirun -n 2 ./amrvac -i test.par

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -39,11 +39,5 @@ jobs:
 
       - name: compile and run tests
         run: |
-          #cd tests
-          #NUM_PROCS=2 ARCH=nvidia OPENACC=1 ./test_runner.sh
-          # Single test for now - just to see if it runs
-          cd tests/hd/KH3D
-          source $AMRVAC_DIR/.venv/bin/activate
-          make arch=nvidia OPENACC=1 
-          ldd amrvac
-          mpirun -n 2 ./amrvac -i test.par
+          cd tests
+          NUM_PROCS=2 ARCH=nvidia OPENACC=1 ./test_runner.sh

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -1,4 +1,4 @@
-name: gpu
+name: tests (GPU)
 
 on:
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: tests
+name: tests (CPU)
 
 on:
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
     name: ${{ matrix.os }} / ${{ matrix.FC_compiler }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: install dependencies
         run: |
           if [[ $RUNNER_OS == "Linux" ]]; then
@@ -76,7 +76,7 @@ jobs:
       AMRVAC_DIR: ${{ github.workspace }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: setup for Intel oneAPI
         # see https://www.intel.com/content/www/us/en/develop/documentation/installation-guide-for-intel-oneapi-toolkits-linux
         run: |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![tests](https://github.com/amrvac/AGILE-experimental/actions/workflows/tests.yml/badge.svg)](https://github.com/amrvac/AGILE-experimental/actions/workflows/tests.yml)
+[![tests (CPU)](https://github.com/amrvac/AGILE-experimental/actions/workflows/tests.yml/badge.svg)](https://github.com/amrvac/AGILE-experimental/actions/workflows/tests.yml)
+[![tests (GPU)](https://github.com/amrvac/AGILE-experimental/actions/workflows/gpu.yml/badge.svg)](https://github.com/amrvac/AGILE-experimental/actions/workflows/gpu.yml)
 
 # AGILE
 

--- a/tests/test_rules.make
+++ b/tests/test_rules.make
@@ -10,6 +10,7 @@ $(error AMRVAC_DIR is not set)
 endif
 
 ARCH ?= gnu
+OPENACC ?= 0
 
 # Disable built-in make rules
 .SUFFIXES:
@@ -27,6 +28,12 @@ else
 MPIRUN_ARG = --oversubscribe
 endif
 
+# Make options
+MAKE_ARGS = arch=$(ARCH)
+ifeq ($(strip $(OPENACC)),1)
+MAKE_ARGS += OPENACC=1
+endif
+
 # force is a dummy to force re-running tests
 .PHONY: all clean force
 
@@ -40,6 +47,7 @@ include $(AMRVAC_DIR)/arch/$(ARCH).mk
 
 F90 := $(compile)
 F90FLAGS := $(f90_flags)
+F90LINKFLAGS := $(link_flags)
 
 %.log: $(LOG_CMP) amrvac force
 	@$(RM) $@		# Remove log to prevent pass when aborted
@@ -52,12 +60,12 @@ F90FLAGS := $(f90_flags)
 	fi
 
 amrvac: force		# Always try a fresh build
-	@$(MAKE) arch=$(ARCH) clean
-	@$(MAKE) -j arch=$(ARCH)
+	@$(MAKE) $(MAKE_ARGS) clean
+	@$(MAKE) -j $(MAKE_ARGS)
 
 # To make sure the comparison utility can be build
 $(LOG_CMP).o: $(LOG_CMP).f
 	$(F90) $(F90FLAGS) -c $< -o $@
 
 $(LOG_CMP): $(LOG_CMP).o
-	$(F90) $< -o $@
+	$(F90) $(F90LINKFLAGS) $< -o $@


### PR DESCRIPTION
Added workflow for running on Haydn.
It runs the same tests as on the CPU on Github, but with the Nvidia compiler and OpenACC enabled.