### PR TITLE
Make tests use same settings as normal compilation: arch instead of ARCH

### DIFF
--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -40,4 +40,4 @@ jobs:
       - name: compile and run tests
         run: |
           cd tests
-          NUM_PROCS=2 ARCH=nvidia OPENACC=1 ./test_runner.sh
+          NUM_PROCS=2 arch=nvidia OPENACC=1 ./test_runner.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: compile and run tests
         run: |
           cd tests
-          ARCH=gnu ./test_runner.sh
+          arch=gnu ./test_runner.sh
 
   INTEL:
     strategy:
@@ -105,4 +105,4 @@ jobs:
       - name: compile
         run: |
           cd tests
-          ARCH=ifx ./test_runner.sh
+          arch=ifx ./test_runner.sh

--- a/tests/test_rules.make
+++ b/tests/test_rules.make
@@ -9,8 +9,7 @@ ifndef AMRVAC_DIR
 $(error AMRVAC_DIR is not set)
 endif
 
-ARCH ?= gnu
-OPENACC ?= 0
+arch ?= gnu
 
 # Disable built-in make rules
 .SUFFIXES:
@@ -22,16 +21,10 @@ LOG_CMP := $(AMRVAC_DIR)/tools/fortran/compare_logs
 NUM_PROCS ?= 4
 
 # Enable oversubscription
-ifeq ($(strip $(ARCH)),ifx)
+ifeq ($(strip $(arch)),ifx)
 MPIRUN_ARG = -genv I_MPI_PIN=0
 else
 MPIRUN_ARG = --oversubscribe
-endif
-
-# Make options
-MAKE_ARGS = arch=$(ARCH)
-ifeq ($(strip $(OPENACC)),1)
-MAKE_ARGS += OPENACC=1
 endif
 
 # force is a dummy to force re-running tests
@@ -43,7 +36,7 @@ clean:
 	$(RM) $(TESTS) amrvac *.vtu *.dat *.log *.f90 *.mod
 
 # Include architecture and compilation rules for the compare_log utility
-include $(AMRVAC_DIR)/arch/$(ARCH).mk
+include $(AMRVAC_DIR)/arch/$(arch).mk
 
 F90 := $(compile)
 F90FLAGS := $(f90_flags)
@@ -60,8 +53,8 @@ F90LINKFLAGS := $(link_flags)
 	fi
 
 amrvac: force		# Always try a fresh build
-	@$(MAKE) $(MAKE_ARGS) clean
-	@$(MAKE) -j $(MAKE_ARGS)
+	@$(MAKE) clean
+	@$(MAKE) -j
 
 # To make sure the comparison utility can be build
 $(LOG_CMP).o: $(LOG_CMP).f

--- a/tests/test_rules.make
+++ b/tests/test_rules.make
@@ -20,11 +20,20 @@ LOG_CMP := $(AMRVAC_DIR)/tools/fortran/compare_logs
 # Number of MPI processes to use
 NUM_PROCS ?= 4
 
-# Enable oversubscription
-ifeq ($(strip $(arch)),ifx)
-MPIRUN_ARG = -genv I_MPI_PIN=0
+# Launcher to use
+LAUNCHER ?= mpirun
+
+# Enable oversubscription and set number of processes
+ifeq ($(strip $(LAUNCHER)),srun)
+# Number of processes is set by slurm
+LAUNCHER_ARG = --overlap
 else
-MPIRUN_ARG = --oversubscribe
+# assume mpirun-compatible launcher
+ifeq ($(strip $(arch)),ifx)
+LAUNCHER_ARG = -genv I_MPI_PIN=0 -np $(NUM_PROCS)
+else
+LAUNCHER_ARG = --oversubscribe -np $(NUM_PROCS)
+endif
 endif
 
 # force is a dummy to force re-running tests
@@ -46,7 +55,7 @@ F90LINKFLAGS := $(link_flags)
 	@$(RM) $@		# Remove log to prevent pass when aborted
 # for Intel same machine
 # @mpirun -genv I_MPI_FABRICS shm  -np $(NUM_PROCS) ./amrvac -i $(filter %.par,$^) > run.log
-	@mpirun $(MPIRUN_ARG) -np $(NUM_PROCS) ./amrvac -i $(filter %.par,$^) > run.log
+	@$(LAUNCHER) $(LAUNCHER_ARG) ./amrvac -i $(filter %.par,$^) > run.log
 	@if $(LOG_CMP) 1.0e-5 1.0e-8 $@ correct_output/$@ ; \
 	then echo -e "$(_green)PASSED$(_reset) $@" ; \
 	else echo -e "$(_red)** FAILED **$(_reset) $@" ; \

--- a/tests/test_rules.make
+++ b/tests/test_rules.make
@@ -20,20 +20,14 @@ LOG_CMP := $(AMRVAC_DIR)/tools/fortran/compare_logs
 # Number of MPI processes to use
 NUM_PROCS ?= 4
 
-# Launcher to use
-LAUNCHER ?= mpirun
-
 # Enable oversubscription and set number of processes
-ifeq ($(strip $(LAUNCHER)),srun)
-# Number of processes is set by slurm
-LAUNCHER_ARG = --overlap
+ifeq ($(strip $(arch)),cray)
+# No mpirun available, use srun. Number of processes is set by slurm
+LAUNCHER = srun --overlap
+else ifeq ($(strip $(arch)),ifx)
+LAUNCHER = mpirun -genv I_MPI_PIN=0 -np $(NUM_PROCS)
 else
-# assume mpirun-compatible launcher
-ifeq ($(strip $(arch)),ifx)
-LAUNCHER_ARG = -genv I_MPI_PIN=0 -np $(NUM_PROCS)
-else
-LAUNCHER_ARG = --oversubscribe -np $(NUM_PROCS)
-endif
+LAUNCHER = mpirun --oversubscribe -np $(NUM_PROCS)
 endif
 
 # force is a dummy to force re-running tests
@@ -53,9 +47,9 @@ F90LINKFLAGS := $(link_flags)
 
 %.log: $(LOG_CMP) amrvac force
 	@$(RM) $@		# Remove log to prevent pass when aborted
-# for Intel same machine
-# @mpirun -genv I_MPI_FABRICS shm  -np $(NUM_PROCS) ./amrvac -i $(filter %.par,$^) > run.log
-	@$(LAUNCHER) $(LAUNCHER_ARG) ./amrvac -i $(filter %.par,$^) > run.log
+    # for Intel same machine
+    # @mpirun -genv I_MPI_FABRICS shm  -np $(NUM_PROCS) ./amrvac -i $(filter %.par,$^) > run.log
+	@$(LAUNCHER) ./amrvac -i $(filter %.par,$^) > run.log
 	@if $(LOG_CMP) 1.0e-5 1.0e-8 $@ correct_output/$@ ; \
 	then echo -e "$(_green)PASSED$(_reset) $@" ; \
 	else echo -e "$(_red)** FAILED **$(_reset) $@" ; \

--- a/tools/fortran/compare_logs.f
+++ b/tools/fortran/compare_logs.f
@@ -56,7 +56,7 @@ contains
     character(len=*), intent(in)         :: fname
     real(dp), allocatable, intent(inout) :: dd(:, :)
     integer                              :: n, n_cols
-    integer, parameter                   :: myunit     = 100
+    integer, parameter                   :: myunit     = 110
     character(len=*), parameter          :: separators = " ,'"""//char(9)
     character(len=line_len)              :: line
     integer                              :: ix_start(max_cols)


### PR DESCRIPTION
Also remove explicit handling of OPENACC arg, this is done automatically when it is set as env var.