### PR TITLE
Handle zero-block ranks in getbc (segfault fix)

### DIFF
--- a/src/mod_ghostcells_update.fpp
+++ b/src/mod_ghostcells_update.fpp
@@ -1145,7 +1145,12 @@ contains
 
     nwhead = nwstart
     nwtail = nwstart+nwbc-1
-    bgstep  = psb(igrids(1))%istep
+    ! igrids(1) is undefined when this rank owns no blocks
+    if (igridstail > 0) then
+       bgstep = psb(igrids(1))%istep
+    else
+       bgstep = 1
+    end if
 
     req_diagonal = .true.
     if (present(req_diag)) req_diagonal = req_diag


### PR DESCRIPTION
When the total number of blocks is less than the number of MPI ranks (e.g. a 64^3 domain with 32^3 blocks on >8 ranks at startup - a plausible situation when using a high number of AMR levels), some ranks own zero blocks. 

getbc was unconditionally reading igrids(1) to determine bgstep, but igrids is uninitialised for empty ranks, causing an immediate segfault. We now check that igridstail > 0 beforehand to prevent this