### PR TITLE
Simplify FFHD HYPERTC source term and make DAT slice output available

### DIFF
--- a/src/ffhd/mod_ffhd_templates.fpp
+++ b/src/ffhd/mod_ffhd_templates.fpp
@@ -250,10 +250,10 @@
     ! Set index for heat flux
 #:if defined('HYPERTC')
     q_ = var_set_q()
-    need_global_cs2max = .true.
+    need_global_cmax = .true.
     hypertc_kappa = 8.d-7*unit_temperature**3.5_dp/unit_length/unit_density/unit_velocity**3.0_dp
     !$acc update device(q_)
-    !$acc update device(need_global_cs2max)
+    !$acc update device(need_global_cmax)
     !$acc update device(hypertc_kappa)
 #:endif
 
@@ -316,7 +316,6 @@ subroutine addsource_local(qdt, dtfactor, qtC, wCT, wCTprim, qt, wnew, x, dr, &
   use mod_radiative_cooling, only: radiative_cooling_add_source
 #:endif
 
-  use mod_global_parameters, only : dt, cs2max_global
   real(dp), intent(in)     :: qdt, dtfactor, qtC, qt
   real(dp), intent(in)     :: wCT(nw_phys), wCTprim(nw_phys)
   real(dp), intent(in)     :: x(1:ndim), dr(ndim)
@@ -364,7 +363,7 @@ end subroutine addsource_local
 subroutine addsource_nonlocal(qdt, dtfactor, qtC, wCTprim, qt, wnew, x, dx, idir, &
      qsourcesplit)
   !$acc routine seq
-  use mod_global_parameters, only: dt, cs2max_global
+  use mod_global_parameters, only: dt, cmax_global, courantpar, third
 
   real(dp), intent(in)     :: qdt, dtfactor, qtC, qt
   real(dp), intent(in)     :: wCTprim(nw_phys,5)
@@ -373,8 +372,8 @@ subroutine addsource_nonlocal(qdt, dtfactor, qtC, wCTprim, qt, wnew, x, dx, idir
   integer, intent(in)      :: idir
   logical, intent(in)      :: qsourcesplit
   ! .. local ..
-  real(dp)                 :: Te, tau, htc_qrsc, sigT, taumin
-  real(dp)                 :: T(1:5), gradT, Tface(2)
+  real(dp)                 :: tau, htc_qrsc, sigT
+  real(dp)                 :: Te(1:5), gradT
   real(dp)                 :: mag5(1:5), divb, mag
 
   if (.not. qsourcesplit) then 
@@ -391,24 +390,18 @@ subroutine addsource_nonlocal(qdt, dtfactor, qtC, wCTprim, qt, wnew, x, dx, idir
 
 #:if defined('HYPERTC')
      !> gradient of temperature:
-     T(1:5) = wCTprim(iw_e,1:5) / wCTprim(iw_rho,1:5)
+     Te(1:5) = wCTprim(iw_e,1:5) / wCTprim(iw_rho,1:5)
      mag = wCTprim(iw_b1-1+idir,3)
 
-     Tface(1) = (7.0d0*(T(2)+T(3))-(T(1)+T(4)))/12.0d0
-     Tface(2) = (7.0d0*(T(3)+T(4))-(T(2)+T(5)))/12.0d0
-     gradT    = (Tface(2)-Tface(1)) / dx(idir)
+     gradT = (8.d0*(Te(4)-Te(2))-Te(5)+Te(1))/(12.d0*dx(idir))
 
-     Te     = wCTprim(iw_e,3) / wCTprim(iw_rho,3)
-     sigT   = hypertc_kappa * sqrt(Te**5)
-     taumin = 4.d0
-
-     tau = taumin
-     tau = max( taumin*dt, sigT*Te*(phys_gamma-1.0d0)/wCTprim(iw_e,3)/cs2max_global)
+     sigT = hypertc_kappa * sqrt(Te(3)**5)
+     tau = max(4.d0*dt, sigT*Te(3)*courantpar**2*(phys_gamma-1.0d0)/&
+        (wCTprim(iw_e,3)*cmax_global**2))
 
      htc_qrsc = sigT * mag * gradT
-     htc_qrsc = ( htc_qrsc + wCTprim(iw_q,3)/3.0_dp ) / tau
 
-     wnew(iw_q) = wnew(iw_q) - qdt * htc_qrsc
+     wnew(iw_q) = wnew(iw_q) - qdt * (htc_qrsc + wCTprim(iw_q,3)*third) / tau
 #:endif
 
   else
@@ -503,16 +496,6 @@ pure real(dp) function get_cmax(u, x, flux_dim) result(wC)
 
 end function get_cmax
 #:enddef  
-
-#:def get_cs2()
-!> obtain the squared sound speed
-pure real(dp) function get_cs2(u) result(cs2)
-  !$acc routine seq
-  real(dp), intent(in)  :: u(nw_phys)
-
-  cs2 = phys_gamma*u(iw_e)/u(iw_rho)
-end function get_cs2
-#:enddef
 
 #:def get_rho()
 pure real(dp) function get_rho(w, x) result(rho)

--- a/src/io/mod_input_output.fpp
+++ b/src/io/mod_input_output.fpp
@@ -44,7 +44,6 @@ contains
   !> Read the command line arguments passed to agile
   subroutine read_arguments()
     use mod_global_parameters
-    use mod_slice, only: slicenext
 
     integer                          :: len, stat, n, i, ipars
     integer, parameter               :: max_files = 20 !Maximum number of par files
@@ -2196,7 +2195,6 @@ contains
     use mod_forest
     use mod_physics
     use mod_global_parameters
-    use mod_slice, only: slicenext
     use mod_input_output_helper, only: snapshot_write_header1
     integer, intent(in)                       :: fh           !< File handle
     integer(kind=MPI_OFFSET_KIND), intent(in) :: offset_tree !< Offset of tree info
@@ -2213,7 +2211,6 @@ contains
     use mod_forest
     use mod_global_parameters
     use mod_physics, only: physics_type
-    use mod_slice, only: slicenext
     integer, intent(in)                   :: fh           !< File handle
     integer(MPI_OFFSET_KIND), intent(out) :: offset_tree !< Offset of tree info
     integer(MPI_OFFSET_KIND), intent(out) :: offset_block !< Offset of block data
@@ -2581,7 +2578,6 @@ contains
     use mod_input_output_helper, only: count_ix
     use mod_forest
     use mod_global_parameters
-    use mod_slice, only: slicenext
     use mod_amr_solution_node, only: alloc_node
     use mod_functions_forest, only: read_forest
 

--- a/src/io/mod_input_output_helper.fpp
+++ b/src/io/mod_input_output_helper.fpp
@@ -137,7 +137,6 @@ module mod_input_output_helper
     use mod_forest
     use mod_physics
     use mod_global_parameters
-    use mod_slice, only: slicenext
     integer, intent(in)                       :: fh           !< File handle
     integer(kind=MPI_OFFSET_KIND), intent(in) :: offset_tree !< Offset of tree info
     integer(kind=MPI_OFFSET_KIND), intent(in) :: offset_block !< Offset of block data

--- a/src/io/mod_slice.fpp
+++ b/src/io/mod_slice.fpp
@@ -16,9 +16,6 @@ module mod_slice
   !> Slice coordinates, see @ref slices.md
   double precision :: slicecoord(nslicemax)
 
-  !> the file number of slices
-  integer :: slicenext
-
   !> Number of slices to output
   integer :: nslices
 
@@ -30,6 +27,9 @@ module mod_slice
 
   !> tag for MPI message
   integer, private :: itag
+
+  !> igrid and ipe of blocks on the slice. Row 0 stores leaf/parent counts.
+  integer, allocatable :: sfc_sub(:,:)
 
 contains
 
@@ -69,6 +69,9 @@ contains
         type_subblockC_x_io
     integer, dimension(ndim) :: sizes, subsizes, start
     double precision,dimension(0:nw+nwauxio)          :: normconv
+    double precision, dimension(ndim-1) :: xprobminsub, xprobmaxsub
+    integer, dimension(ndim-1) :: block_nx_sub, domain_nx_sub
+    logical, dimension(ndim-1) :: periodBsub
 
     ! Preamble:
     nx1=ixMhi1-ixMlo1+1;nx2=ixMhi2-ixMlo2+1;nx3=ixMhi3-ixMlo3+1;
@@ -113,6 +116,11 @@ contains
        subsizes(1)=nx2;subsizes(2)=nx3;
        start(1)=ixMlo2-1;start(2)=ixMlo3-1;
        size_subblock_io=nx2*nx3*(nw+nwexpand)*size_double
+       xprobminsub(1)=xprobmin2; xprobmaxsub(1)=xprobmax2;
+       xprobminsub(2)=xprobmin3; xprobmaxsub(2)=xprobmax3;
+       domain_nx_sub(1)=domain_nx2; domain_nx_sub(2)=domain_nx3;
+       block_nx_sub(1)=block_nx2; block_nx_sub(2)=block_nx3;
+       periodBsub(1)=periodB(2); periodBsub(2)=periodB(3);
     case (2)
        sizes(1) = ixGhi1; sizes(2) = ixGhi3;
        ixsubGlo(1) = ixGlo1; ixsubGlo(2) = ixGlo3;
@@ -120,6 +128,11 @@ contains
        subsizes(1)=nx1;subsizes(2)=nx3;
        start(1)=ixMlo1-1;start(2)=ixMlo3-1;
        size_subblock_io=nx1*nx3*(nw+nwexpand)*size_double
+       xprobminsub(1)=xprobmin1; xprobmaxsub(1)=xprobmax1;
+       xprobminsub(2)=xprobmin3; xprobmaxsub(2)=xprobmax3;
+       domain_nx_sub(1)=domain_nx1; domain_nx_sub(2)=domain_nx3;
+       block_nx_sub(1)=block_nx1; block_nx_sub(2)=block_nx3;
+       periodBsub(1)=periodB(1); periodBsub(2)=periodB(3);
     case (3)
        ixsubGlo(1) = ixGlo1; ixsubGlo(2) = ixGlo2;
        ixsubGhi(1) = ixGhi1; ixsubGhi(2) = ixGhi2;
@@ -127,6 +140,11 @@ contains
        subsizes(1)=nx1;subsizes(2)=nx2;
        start(1)=ixMlo1-1;start(2)=ixMlo2-1;
        size_subblock_io=nx1*nx2*(nw+nwexpand)*size_double
+       xprobminsub(1)=xprobmin1; xprobmaxsub(1)=xprobmax1;
+       xprobminsub(2)=xprobmin2; xprobmaxsub(2)=xprobmax2;
+       domain_nx_sub(1)=domain_nx1; domain_nx_sub(2)=domain_nx2;
+       block_nx_sub(1)=block_nx1; block_nx_sub(2)=block_nx2;
+       periodBsub(1)=periodB(1); periodBsub(2)=periodB(2);
     case default
        call mpistop("slice direction not clear in put_slice")
     end select
@@ -203,6 +221,7 @@ contains
     call MPI_TYPE_FREE(type_subblockC_io,ierrmpi)
     call MPI_TYPE_FREE(type_subblockC_x_io,ierrmpi)
 
+    if (allocated(sfc_sub)) deallocate(sfc_sub)
 
   contains
 
@@ -570,16 +589,65 @@ contains
     end subroutine put_slice_line
 
     subroutine put_slice_dat
+      use mod_forest, only: tree_node, igrid_to_node
+      use mod_input_output_helper, only: version_number, save_now
+      use mod_physics, only: physics_type, phys_write_info
 
-      integer, dimension(max_blocks) :: iorequest
-      integer, dimension(MPI_STATUS_SIZE,max_blocks) :: iostatus
-      integer(kind=MPI_OFFSET_KIND) :: offset
+      integer, dimension(max_blocks*2) :: iorequest
+      integer, dimension(MPI_STATUS_SIZE,max_blocks*2) :: iostatus
+      integer(kind=MPI_OFFSET_KIND) :: offset, offset1
       integer :: nsubleafs
       character(len=1024) :: filename, xlabel
       character(len=79)   :: xxlabel
       integer :: amode, status(MPI_STATUS_SIZE), iwrite
+      character(len=name_len) :: dname
+
+      integer :: nsubparents, iw, ileaf, inode
+      integer :: n_ghost_sub(2*(ndim-1))
+      integer(kind=MPI_OFFSET_KIND) :: block_offset, tree_offset
+      integer, allocatable :: block_ig_sub(:,:)
+      integer, allocatable :: block_lvl_sub(:)
+      integer(kind=MPI_OFFSET_KIND), allocatable :: block_offset_sub(:)
+      logical, allocatable :: isleaf_sub(:)
+      type(tree_node), pointer :: pnode
 
       nsubleafs=Morton_sub_stop(npe-1)
+
+      if (mype==0) then
+
+         if (nsubleafs /= sfc_sub(0,1)) error stop "nsubleafs /= sfc_sub(0,1)"
+         nsubparents = sfc_sub(0,2)
+         allocate(block_ig_sub(ndim-1,nsubleafs))
+         allocate(block_lvl_sub(nsubleafs))
+         allocate(block_offset_sub(nsubleafs))
+         allocate(isleaf_sub(nsubleafs+nsubparents))
+
+         block_offset = int(0,kind=MPI_OFFSET_KIND)
+         ileaf = 0
+         do inode=1,nsubleafs+nsubparents
+            if (sfc_sub(inode,1) == 0) then
+               isleaf_sub(inode) = .false.
+            else
+               isleaf_sub(inode) = .true.
+               pnode => igrid_to_node(sfc_sub(inode,1),sfc_sub(inode,2))%node
+               ileaf = ileaf + 1
+               select case (dir)
+               case (1)
+                  block_ig_sub(:,ileaf) = [ pnode%ig2, pnode%ig3 ]
+               case (2)
+                  block_ig_sub(:,ileaf) = [ pnode%ig1, pnode%ig3 ]
+               case (3)
+                  block_ig_sub(:,ileaf) = [ pnode%ig1, pnode%ig2 ]
+               end select
+               block_lvl_sub(ileaf) = pnode%level
+               block_offset_sub(ileaf) = block_offset
+               block_offset = block_offset + int(2*(ndim-1)*size_int,kind=MPI_OFFSET_KIND)
+               block_offset = block_offset + int(product(block_nx_sub)*nw*size_double,&
+                  kind=MPI_OFFSET_KIND)
+            end if
+         end do
+      end if
+
       ! generate filename
       write(xlabel,"(D9.2)")xslice
       xxlabel=trim(xlabel)
@@ -594,16 +662,122 @@ contains
          close(unit=slice_fh)
       end if
 
+      if (mype==0) then
+         amode=ior(MPI_MODE_APPEND,MPI_MODE_WRONLY)
+         call MPI_FILE_OPEN(MPI_COMM_SELF,filename,amode,MPI_INFO_NULL,&
+            slice_fh,ierrmpi)
+
+         call MPI_FILE_WRITE(slice_fh, version_number, 1, MPI_INTEGER, status,&
+            ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, 0, 1, MPI_INTEGER, status, ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, 0, 1, MPI_INTEGER, status, ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, nw, 1, MPI_INTEGER, status, ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, ndir, 1, MPI_INTEGER, status, ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, ndim-1, 1, MPI_INTEGER, status, ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, levmax_sub, 1, MPI_INTEGER, status,&
+            ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, nsubleafs, 1, MPI_INTEGER, status,&
+            ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, nsubparents, 1, MPI_INTEGER, status,&
+            ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, it, 1, MPI_INTEGER, status, ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, global_time, 1, MPI_DOUBLE_PRECISION,&
+            status,ierrmpi)
+
+         call MPI_FILE_WRITE(slice_fh, xprobminsub, ndim-1,&
+            MPI_DOUBLE_PRECISION, status, ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, xprobmaxsub, ndim-1,&
+            MPI_DOUBLE_PRECISION, status, ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, domain_nx_sub, ndim-1, MPI_INTEGER,&
+            status, ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, block_nx_sub, ndim-1, MPI_INTEGER,&
+            status, ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, periodBsub, ndim-1, MPI_LOGICAL,&
+            status, ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, geometry_name(1:name_len), name_len,&
+            MPI_CHARACTER, status, ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, stagger_grid, 1, MPI_LOGICAL, status,&
+            ierrmpi)
+
+         do iw = 1, nw
+            dname = trim(adjustl(cons_wnames(iw)))
+            call MPI_FILE_WRITE(slice_fh, dname, name_len, MPI_CHARACTER,&
+               status, ierrmpi)
+         end do
+
+         call MPI_FILE_WRITE(slice_fh, physics_type, name_len, MPI_CHARACTER,&
+            status, ierrmpi)
+         call phys_write_info(slice_fh)
+
+         if(pass_wall_time.or.save_now) then
+            call MPI_FILE_WRITE(slice_fh, snapshotnext, 1, MPI_INTEGER, status,&
+               ierrmpi)
+         else
+            call MPI_FILE_WRITE(slice_fh, snapshotnext+1, 1, MPI_INTEGER,&
+               status, ierrmpi)
+         end if
+         call MPI_FILE_WRITE(slice_fh, slicenext, 1, MPI_INTEGER, status,&
+            ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, collapsenext, 1, MPI_INTEGER, status,&
+            ierrmpi)
+
+         call MPI_FILE_GET_POSITION(slice_fh, tree_offset, ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, isleaf_sub, nsubleafs+nsubparents,&
+            MPI_LOGICAL, status, ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, block_lvl_sub, nsubleafs, MPI_INTEGER,&
+            status, ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, block_ig_sub, size(block_ig_sub),&
+            MPI_INTEGER, status, ierrmpi)
+
+         call MPI_FILE_GET_POSITION(slice_fh, block_offset, ierrmpi)
+         block_offset_sub(:) = block_offset_sub(:) + block_offset + &
+            int(nsubleafs*2*size_int, kind=MPI_OFFSET_KIND)
+
+         call MPI_FILE_WRITE(slice_fh, block_offset_sub, nsubleafs, MPI_OFFSET,&
+            status, ierrmpi)
+
+         call MPI_FILE_GET_POSITION(slice_fh, block_offset, ierrmpi)
+         if (block_offset - tree_offset /= &
+            (nsubleafs + nsubparents) * size_logical + &
+            nsubleafs * ((ndim-1+1) * size_int + 2 * size_int)) then
+            print *, "Warning: MPI_OFFSET type /= 8 bytes"
+            print *, "This *could* cause problems when reading .dat files"
+         end if
+
+         call MPI_FILE_SEEK(slice_fh, int(size_int,kind=MPI_OFFSET_KIND),&
+            MPI_SEEK_SET, ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, int(tree_offset), 1, MPI_INTEGER,&
+            status, ierrmpi)
+         call MPI_FILE_WRITE(slice_fh, int(block_offset), 1, MPI_INTEGER,&
+            status, ierrmpi)
+
+         call MPI_FILE_CLOSE(slice_fh,ierrmpi)
+      end if
+
+      call MPI_BCAST(nsubleafs, 1, MPI_INTEGER, 0, icomm, ierrmpi)
+      call MPI_BCAST(nsubparents, 1, MPI_INTEGER, 0, icomm, ierrmpi)
+
+      if (mype /= 0) then
+         allocate(block_offset_sub(nsubleafs))
+      end if
+
+      call MPI_BCAST(block_offset_sub, nsubleafs, MPI_OFFSET, 0, icomm,&
+         ierrmpi)
+
       amode=ior(MPI_MODE_CREATE,MPI_MODE_WRONLY)
       call MPI_FILE_OPEN(icomm,filename,amode,MPI_INFO_NULL,slice_fh,ierrmpi)
       iorequest=MPI_REQUEST_NULL
       iwrite=0
+      n_ghost_sub = 0
 
       do jgrid=1,Njgrid
          iwrite=iwrite+1
-         offset=int(size_subblock_io,kind=MPI_OFFSET_KIND) &
-            *int(Morton_sub_start(mype)+jgrid-2,kind=MPI_OFFSET_KIND)
-         call MPI_FILE_IWRITE_AT(slice_fh,offset,ps_sub(jgrid)%w,1,&
+         offset=block_offset_sub(int(Morton_sub_start(mype)+jgrid-1))
+         call MPI_FILE_IWRITE_AT(slice_fh,offset,n_ghost_sub,2*(ndim-1),&
+            MPI_INTEGER, iorequest(iwrite),ierrmpi)
+         iwrite=iwrite+1
+         offset1=offset+int(2*(ndim-1)*size_int,kind=MPI_OFFSET_KIND)
+         call MPI_FILE_IWRITE_AT(slice_fh,offset1,ps_sub(jgrid)%w,1,&
             type_subblock_io, iorequest(iwrite),ierrmpi)
       end do
 
@@ -611,30 +785,11 @@ contains
       call MPI_BARRIER(icomm, ierrmpi)
       call MPI_FILE_CLOSE(slice_fh,ierrmpi)
 
+      deallocate(block_offset_sub)
       if (mype==0) then
-         amode=ior(MPI_MODE_APPEND,MPI_MODE_WRONLY)
-         call MPI_FILE_OPEN(MPI_COMM_SELF,filename,amode,MPI_INFO_NULL,&
-             slice_fh,ierrmpi)
-
-         call select_slice(dir,xslice,.true.,slice_fh,normconv)
-
-         call MPI_FILE_WRITE(slice_fh,subsizes(2-1),1,MPI_INTEGER,status,&
-            ierrmpi)
-         call MPI_FILE_WRITE(slice_fh,subsizes(3-1),1,MPI_INTEGER,status,&
-            ierrmpi)
-!         call MPI_FILE_WRITE(slice_fh,eqpar,neqpar+nspecialpar, &
-!              MPI_DOUBLE_PRECISION,status,ierrmpi)
-         call MPI_FILE_WRITE(slice_fh,nsubleafs,1,MPI_INTEGER,status,ierrmpi)
-         call MPI_FILE_WRITE(slice_fh,levmax_sub,1,MPI_INTEGER,status,ierrmpi)
-         call MPI_FILE_WRITE(slice_fh,ndim-1,1,MPI_INTEGER,status,ierrmpi)
-         call MPI_FILE_WRITE(slice_fh,ndir,1,MPI_INTEGER,status,ierrmpi)
-         call MPI_FILE_WRITE(slice_fh,nw,1,MPI_INTEGER,status,ierrmpi)
-!         call MPI_FILE_WRITE(slice_fh,neqpar+nspecialpar,1,MPI_INTEGER,status,ierrmpi)
-         call MPI_FILE_WRITE(slice_fh,it,1,MPI_INTEGER,status,ierrmpi)
-         call MPI_FILE_WRITE(slice_fh,global_time,1,MPI_DOUBLE_PRECISION,&
-            status,ierrmpi)
-
-         call MPI_FILE_CLOSE(slice_fh,ierrmpi)
+         deallocate(block_ig_sub)
+         deallocate(block_lvl_sub)
+         deallocate(isleaf_sub)
       end if
 
     end subroutine put_slice_dat
@@ -658,8 +813,8 @@ contains
   end subroutine put_slice
 
   subroutine select_slice(dir,xslice,writeonly,file_handle,normconv)
-    use mod_forest, only: tree_node_ptr, tree_root, Morton_sub_start,&
-        Morton_sub_stop
+    use mod_forest, only: iglevel1_sfc, sfc_iglevel1, tree_node_ptr,&
+        tree_root, Morton_sub_start, Morton_sub_stop
     use mod_global_parameters
     integer, intent(in) :: dir
     double precision, intent(in) :: xslice
@@ -669,40 +824,59 @@ contains
     ! .. local ..
     integer :: ig1,ig2,ig3, jgrid, slice_fh, ipe, mylevmax
     integer, dimension(nlevelshi) :: igslice
+    integer, allocatable :: iglevel1_sub_sfc(:)
+    integer :: igmin1, igmin2, igmin3, igmax1, igmax2, igmax3, ngsub1,&
+       jglevel1, igsorted, kgrid, ngmax
 
+    kgrid = 0
     jgrid = 0
     mylevmax = 0
+    jglevel1 = 0
 
     ! Find the global slice index for every level:
     call get_igslice(dir,xslice,igslice)
+    igmin1=1; igmin2=1; igmin3=1;
+    igmax1=ng1(1); igmax2=ng2(1); igmax3=ng3(1);
 
     ! Traverse forest to find grids indicating slice:
 
     select case(dir)
     case (1)
-       ig1 = igslice(1)
-       do ig3=1,ng3(1)
-          do ig2=1,ng2(1)
-             call traverse_slice(tree_root(ig1,ig2,ig3))
-          end do
-       end do
+       igmin1=igslice(1); igmax1=igslice(1);
     case (2)
-       ig2 = igslice(1)
-       do ig3=1,ng3(1)
-          do ig1=1,ng1(1)
-             call traverse_slice(tree_root(ig1,ig2,ig3))
-          end do
-       end do
+       igmin2=igslice(1); igmax2=igslice(1);
     case (3)
-       ig3 = igslice(1)
-       do ig2=1,ng2(1)
-          do ig1=1,ng1(1)
-             call traverse_slice(tree_root(ig1,ig2,ig3))
-          end do
-       end do
+       igmin3=igslice(1); igmax3=igslice(1);
     case default
        call mpistop("slice direction not clear in select_slice")
     end select
+
+    ngsub1=((igmax1-igmin1+1)*(igmax2-igmin2+1)*(igmax3-igmin3+1))
+    allocate(iglevel1_sub_sfc(ngsub1))
+    if (.not. allocated(sfc_sub)) then
+       ngmax = ngsub1*(4**refine_max_level-1)
+       allocate(sfc_sub(0:ngmax,1:3))
+       sfc_sub = 0
+    end if
+
+    do ig3=igmin3,igmax3
+       do ig2=igmin2,igmax2
+          do ig1=igmin1,igmax1
+             jglevel1=jglevel1+1
+             iglevel1_sub_sfc(jglevel1)=iglevel1_sfc(ig1,ig2,ig3)
+          end do
+       end do
+    end do
+
+    call quicksort_integer(iglevel1_sub_sfc, 1, ngsub1)
+
+    do igsorted=1,ngsub1
+       ig1 = sfc_iglevel1(1,iglevel1_sub_sfc(igsorted))
+       ig2 = sfc_iglevel1(2,iglevel1_sub_sfc(igsorted))
+       ig3 = sfc_iglevel1(3,iglevel1_sub_sfc(igsorted))
+       call traverse_slice(tree_root(ig1,ig2,ig3))
+    end do
+    deallocate(iglevel1_sub_sfc)
 
 
 
@@ -734,11 +908,18 @@ contains
       implicit none
       type(tree_node_ptr) :: tree
       integer :: ic1,ic2,ic3
-      integer, dimension(MPI_STATUS_SIZE) :: status
 
-      if (writeonly) then
-         call MPI_FILE_WRITE(file_handle,tree%node%leaf,1,MPI_LOGICAL, status,&
-            ierrmpi)
+      if (mype==0) then
+         kgrid = kgrid + 1
+         sfc_sub(kgrid,1) = tree%node%igrid
+         sfc_sub(kgrid,2) = tree%node%ipe
+         if (tree%node%leaf) then
+            sfc_sub(0,1) = sfc_sub(0,1) + 1
+            sfc_sub(kgrid,3) = 1
+         else
+            sfc_sub(0,2) = sfc_sub(0,2) + 1
+            sfc_sub(kgrid,3) = 0
+         end if
       end if
 
       if (tree%node%leaf) then
@@ -1338,5 +1519,38 @@ contains
     if (roundoff_minmax /= roundoff_minmax) roundoff_minmax = maxval
 
   end function roundoff_minmax
+
+  recursive subroutine quicksort_integer(arr, left, right)
+    integer, intent(inout) :: arr(:)
+    integer, intent(in) :: left, right
+    integer :: i, j, pivot, temp
+
+    if (left < right) then
+       pivot = arr((left + right) / 2)
+       i = left
+       j = right
+
+       do
+          do while (arr(i) < pivot)
+             i = i + 1
+          end do
+          do while (arr(j) > pivot)
+             j = j - 1
+          end do
+
+          if (i >= j) exit
+
+          temp = arr(i)
+          arr(i) = arr(j)
+          arr(j) = temp
+          i = i + 1
+          j = j - 1
+       end do
+
+       call quicksort_integer(arr, left, j)
+       call quicksort_integer(arr, j + 1, right)
+    end if
+
+  end subroutine quicksort_integer
 
 end module mod_slice

--- a/src/mhd/mod_mhd_templates.fpp
+++ b/src/mhd/mod_mhd_templates.fpp
@@ -586,16 +586,6 @@ pure real(dp) function get_cmax(u, x, flux_dim) result(wC)
 end function get_cmax
 #:enddef  
 
-#:def get_cs2()
-!> obtain the squared sound speed
-pure real(dp) function get_cs2(u) result(cs2)
-  !$acc routine seq
-  real(dp), intent(in)  :: u(nw_phys)
-
-  cs2 = phys_gamma*u(iw_e)/u(iw_rho)
-end function get_cs2
-#:enddef
-
 #:def get_rho()
   pure real(dp) function get_rho(w, x) result(rho)
     !$acc routine seq

--- a/src/mod_dt.fpp
+++ b/src/mod_dt.fpp
@@ -17,7 +17,6 @@ contains
 @:to_primitive()
 @:get_cmax()
 @:phys_get_dt()
-@:get_cs2()
 
   !>setdt  - set dt for all levels between levmin and levmax.
   !>         dtpar>0  --> use fixed dtpar for all level
@@ -28,7 +27,7 @@ contains
     integer :: iigrid, igrid, idims, ix1,ix2,ix3, ifile
     double precision :: dtmin_mype, factor, dx1,dx2,dx3, dtmax
 
-    double precision :: dxinv(1:ndim), cmaxtot, cmax, u(1:nw_phys), cs2max_mype, cmax_mype
+    double precision :: dxinv(1:ndim), cmaxtot, cmax, u(1:nw_phys), cmax_mype
     double precision :: xloc(1:ndim), qdtnew
 
     if (dtpar<=zero) then
@@ -104,27 +103,6 @@ contains
     end if
 
 
-    if (need_global_cs2max) then
-      cs2max_mype=-bigdouble
-      
-      !$acc parallel loop PRIVATE(igrid) REDUCTION(max:cs2max_mype) gang
-      do iigrid=1,igridstail_active; igrid=igrids_active(iigrid)
-
-         !$acc loop vector collapse(ndim) REDUCTION(max:cs2max_mype) private(u)
-         do ix3=ixMlo3,ixMhi3 
-            do ix2=ixMlo2,ixMhi2 
-               do ix1=ixMlo1,ixMhi1
-                  
-                  u(1:nw_phys) = bg(1)%w(ix1, ix2, ix3, 1:nw_phys, igrid)
-                  call to_primitive(u)
-                  cs2max_mype = max( cs2max_mype, get_cs2(u) )
-      
-               end do
-            end do
-         end do
-      end do
-    end if
-
     if (dtmin_mype<dtmin) then
        write(unitterm,*)"Error: Time step too small!", dtmin_mype
        write(unitterm,*)"on processor:", mype, "at time:", global_time,&
@@ -152,11 +130,6 @@ contains
        dt=dtmin_mype
     end if
 
-    if (need_global_cs2max) then
-      call MPI_ALLREDUCE(cs2max_mype, cs2max_global, 1, MPI_DOUBLE_PRECISION, MPI_MAX, icomm, &
-           ierrmpi)
-      !$acc update device(cs2max_global)
-    end if
     if (need_global_cmax) then
       call MPI_ALLREDUCE(cmax_mype, cmax_global, 1, MPI_DOUBLE_PRECISION, MPI_MAX, icomm, &
              ierrmpi)

--- a/src/mod_global_parameters.fpp
+++ b/src/mod_global_parameters.fpp
@@ -713,14 +713,6 @@ module mod_global_parameters
   double precision :: cmax_global
   !$acc declare create(cmax_global)
 
-  !> global fastest sound speed needed for htc
-  double precision :: cs2max_global
-  !$acc declare create(cs2max_global)
-
-  !> global fastest flow speed needed in glm method
-  double precision :: vmax_global
-  !$acc declare create(vmax_global)
-
   !> global largest a2 for schmid scheme
   double precision :: a2max_global(ndim)
   !$acc declare create(a2max_global)
@@ -733,10 +725,6 @@ module mod_global_parameters
   logical :: need_global_a2max=.false.
   !$acc declare create(need_global_a2max)
 
-  !> global value for sound scheme
-  logical :: need_global_cs2max=.false.
-  !$acc declare create(need_global_cs2max)
-  
   ! Boundary region parameters
 
   !> True for dimensions with periodic boundaries

--- a/src/mod_global_parameters.fpp
+++ b/src/mod_global_parameters.fpp
@@ -236,6 +236,9 @@ module mod_global_parameters
   !> IO: snapshot and collapsed views output numbers/labels
   integer :: snapshotnext, collapsenext
 
+  !> IO: slice output numbers/labels
+  integer :: slicenext
+
   !> Constant indicating log output
   integer, parameter :: filelog_      = 1
 

--- a/src/physics/mod_physics_dummies.fpp
+++ b/src/physics/mod_physics_dummies.fpp
@@ -2,24 +2,6 @@
 ! On non-Cray compilers, these call mpistop with a descriptive message.
 ! On Cray, STOP cannot be inlined into OpenACC kernels, so dummies just return -1. 
 
-#:def get_cs2()
-!> obtain the squared sound speed
-real(dp) function get_cs2(u) result(cs2)
-  !$acc routine seq
-#ifndef _CRAYFTN
-  use mod_comm_lib, only: mpistop
-#endif
-  real(dp), intent(in)  :: u(nw_phys)
-
-#ifndef _CRAYFTN
-  call mpistop("get_cs2 not implemented for this physics module")
-#endif
-  cs2 = -1.0d0
-
-end function get_cs2
-#:enddef
-
-
 #:def estimate_speeds_minmax()
 subroutine estimate_speeds_minmax(uL, uR, xC, flux_dim, wL, wR)
   !$acc routine seq


### PR DESCRIPTION
This PR contains two focused updates:

- Reuse the existing `cmax_global` path for FFHD hyperbolic thermal conduction instead of maintaining a separate `cs2max_global` path.
- Simplify the FFHD HYPERTC temperature-gradient stencil to the equivalent direct fourth-order centered expression.
- Port DAT slice output support.

The HYPERTC stencil change is algebraically equivalent to the previous face-based expression. It mainly improves readability and may help compiler/kernel code generation by avoiding small local temporaries.

The `cmax_global` change is primarily a consistency and maintenance cleanup rather than a claimed performance optimization.
