### PR TITLE
Consistently make gamma-1 and 1/(gamma-1) globals, using whichever is…

### DIFF
--- a/src/ffhd/mod_ffhd_templates.fpp
+++ b/src/ffhd/mod_ffhd_templates.fpp
@@ -54,7 +54,9 @@
 
   !> The adiabatic index
   double precision, public                :: ffhd_gamma = 5.d0/3.0d0
-  !$acc declare copyin(ffhd_gamma)
+  double precision, public                :: gamma_1, inv_gamma_1
+  !$acc declare copyin(ffhd_gamma, gamma_1, inv_gamma_1)
+  !$acc declare create(gamma_1, inv_gamma_1)
 
   !> The adiabatic constant
   double precision, public                :: ffhd_adiab = 1.0d0
@@ -227,7 +229,9 @@
     phys_internal_e = .false.
     phys_gamma = ffhd_gamma
     phys_partial_ionization=ffhd_partial_ionization
- !$acc update device(physics_type, phys_energy, phys_total_energy, phys_internal_e, phys_gamma, phys_partial_ionization)
+    gamma_1 = ffhd_gamma - 1.0d0
+    inv_gamma_1 = 1.0d0/gamma_1
+ !$acc update device(physics_type, phys_energy, phys_total_energy, phys_internal_e, phys_gamma, phys_partial_ionization, gamma_1, inv_gamma_1)
 
     ! Determine flux variables
     rho_ = var_set_rho()
@@ -405,7 +409,7 @@ subroutine addsource_nonlocal(qdt, dtfactor, qtC, wCTprim, qt, wnew, x, dx, idir
      gradT = (8.d0*(Te(4)-Te(2))-Te(5)+Te(1))/(12.d0*dx(idir))
 
      sigT = hypertc_kappa * sqrt(Te(3)**5)
-     tau = max(4.d0*dt, sigT*Te(3)*courantpar**2*(phys_gamma-1.0d0)/&
+     tau = max(4.d0*dt, sigT*Te(3)*courantpar**2*gamma_1/&
         (wCTprim(iw_e,3)*cmax_global**2))
 
      htc_qrsc = sigT * mag * gradT
@@ -432,7 +436,7 @@ pure subroutine to_primitive(u)
 
   u(iw_mom(1)) = u(iw_mom(1))/u(iw_rho)
 
-  u(iw_e) = (phys_gamma-1.0_dp) * (u(iw_e) - 0.5_dp * u(iw_rho) * &
+  u(iw_e) = gamma_1 * (u(iw_e) - 0.5_dp * u(iw_rho) * &
      u(iw_mom(1))**2 )
 
 end subroutine to_primitive
@@ -442,12 +446,9 @@ end subroutine to_primitive
 pure subroutine to_conservative(u)
   !$acc routine seq
   real(dp), intent(inout) :: u(nw_phys)
-  real(dp)                :: inv_gamma_m1
-
-  inv_gamma_m1 = 1.0_dp/(phys_gamma - 1.0_dp)
 
   ! Compute energy from pressure and kinetic energy
-  u(iw_e) = u(iw_e) * inv_gamma_m1 + 0.5_dp * u(iw_rho) * &
+  u(iw_e) = u(iw_e) * inv_gamma_1 + 0.5_dp * u(iw_rho) * &
      u(iw_mom(1))**2
 
   ! Compute momentum from density and velocity components
@@ -464,10 +465,7 @@ subroutine get_flux(u, xC, flux_dim, flux)
   real(dp), intent(in)  :: xC(1:ndim)
   integer, intent(in)   :: flux_dim
   real(dp), intent(out) :: flux(nw_flux)
-  real(dp)              :: inv_gamma_m1
   real(dp)              :: mag
-
-  inv_gamma_m1 = 1.0_dp/(phys_gamma - 1.0_dp)
 
   mag = u(iw_b1-1+flux_dim)
 
@@ -478,7 +476,7 @@ subroutine get_flux(u, xC, flux_dim, flux)
   flux(iw_mom(1)) = (u(iw_rho)*u(iw_mom(1))**2 + u(iw_e)) * mag
   
   ! Energy flux with hyperbolic conduction included
-  flux(iw_e) = u(iw_mom(1))*(u(iw_e)*inv_gamma_m1 + &
+  flux(iw_e) = u(iw_mom(1))*(u(iw_e)*inv_gamma_1 + &
                0.5_dp*u(iw_rho)*u(iw_mom(1))**2 + u(iw_e)) * mag + &
 #:if defined('HYPERTC')
   u(iw_q)*mag
@@ -522,7 +520,7 @@ pure real(dp) function get_pthermal(w, x) result(pth)
   real(dp), intent(in)  :: w(nw_phys)
   real(dp), intent(in)  :: x(1:ndim)
 
-  pth = (phys_gamma-1.0_dp)*(w(iw_e)-0.5_dp*w(iw_mom(1))**2/w(iw_rho))
+  pth = gamma_1*(w(iw_e)-0.5_dp*w(iw_mom(1))**2/w(iw_rho))
 end function get_pthermal
 #:enddef
 

--- a/src/hd/mod_hd_templates.fpp
+++ b/src/hd/mod_hd_templates.fpp
@@ -40,7 +40,9 @@
 
   !> The adiabatic index
   double precision, public                :: hd_gamma = 5.d0/3.0d0
+  double precision, public                :: gamma_1, inv_gamma_1
   !$acc declare copyin(hd_gamma)
+  !$acc declare create(gamma_1, inv_gamma_1)
 
   !> The adiabatic constant
   double precision, public                :: hd_adiab = 1.0d0
@@ -206,7 +208,9 @@
     phys_internal_e = .false.
     phys_gamma = hd_gamma
     phys_partial_ionization=hd_partial_ionization
- !$acc update device(physics_type, phys_energy, phys_total_energy, phys_internal_e, phys_gamma, phys_partial_ionization)
+    gamma_1 = hd_gamma - 1.0d0
+    inv_gamma_1 = 1.0d0/gamma_1
+ !$acc update device(physics_type, phys_energy, phys_total_energy, phys_internal_e, phys_gamma, phys_partial_ionization, gamma_1, inv_gamma_1)
 
     use_particles = hd_particles
 
@@ -365,7 +369,7 @@ pure subroutine to_primitive(u)
       u(iw_mom(3)) = u(iw_mom(3))/u(iw_rho)
 
   ! Compute pressure from energy
-  u(iw_e) = (hd_gamma-1.0_dp) * (u(iw_e) - 0.5_dp * u(iw_rho) * &
+  u(iw_e) = gamma_1 * (u(iw_e) - 0.5_dp * u(iw_rho) * &
      sum(u(iw_mom(1:ndim))**2) )
 
 end subroutine to_primitive
@@ -375,12 +379,9 @@ end subroutine to_primitive
 pure subroutine to_conservative(u)
   !$acc routine seq
   real(dp), intent(inout) :: u(nw_phys)
-  real(dp)                :: inv_gamma_m1
-
-  inv_gamma_m1 = 1.0d0/(hd_gamma - 1.0_dp)
 
   ! Compute energy from pressure and kinetic energy
-  u(iw_e) = u(iw_e) * inv_gamma_m1 + 0.5_dp * u(iw_rho) * &
+  u(iw_e) = u(iw_e) * inv_gamma_1 + 0.5_dp * u(iw_rho) * &
      sum(u(iw_mom(1:ndim))**2)
 
   ! Compute momentum from density and velocity components
@@ -398,9 +399,6 @@ subroutine get_flux(u, xC, flux_dim, flux)
   real(dp), intent(in)  :: xC(ndim)
   integer, intent(in)   :: flux_dim
   real(dp), intent(out) :: flux(nw_flux)
-  real(dp)              :: inv_gamma_m1
-
-  inv_gamma_m1 = 1.0d0/(hd_gamma - 1.0_dp)
 
   ! Density flux
   flux(iw_rho) = u(iw_rho) * u(iw_mom(flux_dim))
@@ -414,7 +412,7 @@ subroutine get_flux(u, xC, flux_dim, flux)
   flux(iw_mom(flux_dim)) = flux(iw_mom(flux_dim)) + u(iw_e)
 
   ! Energy flux
-  flux(iw_e) = u(iw_mom(flux_dim)) * (u(iw_e) * inv_gamma_m1 + 0.5_dp * &
+  flux(iw_e) = u(iw_mom(flux_dim)) * (u(iw_e) * inv_gamma_1 + 0.5_dp * &
      u(iw_rho) * sum(u(iw_mom(1:ndim))**2) + u(iw_e))
 
   ! Tracer flux. Note that tracers stay conservative.
@@ -531,7 +529,7 @@ pure double precision function get_pthermal(w, x) result(pth)
   double precision, intent(in)  :: w(nw_flux)
   double precision, intent(in)  :: x(1:ndim)
 
-  pth = (phys_gamma-1.0_dp)*(w(iw_e)-0.5_dp*sum(w(iw_mom(:))**2)/w(iw_rho))
+  pth = gamma_1*(w(iw_e)-0.5_dp*sum(w(iw_mom(:))**2)/w(iw_rho))
 end function get_pthermal
 #:enddef
 

--- a/src/mhd/mod_mhd_templates.fpp
+++ b/src/mhd/mod_mhd_templates.fpp
@@ -52,11 +52,9 @@
 
   !> The adiabatic index
   double precision, public                :: mhd_gamma = 5.d0/3.0d0
+  double precision, public                :: gamma_1, inv_gamma_1
   !$acc declare copyin(mhd_gamma)
-
-  !> The adiabatic index minus 1
-  double precision, public                :: mhd_gamma_m1
-  !$acc declare copyin(mhd_gamma_m1)
+  !$acc declare create(gamma_1, inv_gamma_1)
 
   !> Helium abundance over Hydrogen
   double precision, public  :: He_abundance=0.1d0
@@ -249,8 +247,9 @@
     phys_gamma = mhd_gamma
     phys_partial_ionization=mhd_partial_ionization
     need_global_cmax=.true.
-    mhd_gamma_m1=mhd_gamma-1.0_dp
- !$acc update device(physics_type, phys_energy, phys_total_energy, phys_internal_e, phys_gamma, phys_partial_ionization,need_global_cmax,mhd_gamma_m1)
+    gamma_1=mhd_gamma-1.0_dp
+    inv_gamma_1=1.0_dp/gamma_1
+ !$acc update device(physics_type, phys_energy, phys_total_energy, phys_internal_e, phys_gamma, phys_partial_ionization,need_global_cmax,gamma_1,inv_gamma_1)
 
     use_particles = mhd_particles
 
@@ -509,7 +508,7 @@ end subroutine addsource_compact
     u(iw_mom(1))=u(iw_mom(1))/u(iw_rho)
     u(iw_mom(2))=u(iw_mom(2))/u(iw_rho)
     u(iw_mom(3))=u(iw_mom(3))/u(iw_rho)
-    u(iw_e)=mhd_gamma_m1*(u(iw_e)-0.5_dp*&
+    u(iw_e)=gamma_1*(u(iw_e)-0.5_dp*&
       (u(iw_rho)*(u(iw_mom(1))**2+u(iw_mom(2))**2+u(iw_mom(3))**2)+&
        u(iw_mag(1))**2+u(iw_mag(2))**2+u(iw_mag(3))**2))
 
@@ -522,7 +521,7 @@ end subroutine addsource_compact
     real(dp), intent(inout) :: u(nw_phys)
 
     ! Compute energy from pressure and kinetic energy
-    u(iw_e)=u(iw_e)/mhd_gamma_m1+0.5_dp*&
+    u(iw_e)=u(iw_e)*inv_gamma_1+0.5_dp*&
       (u(iw_rho)*(u(iw_mom(1))**2+u(iw_mom(2))**2+u(iw_mom(3))**2)+&
        u(iw_mag(1))**2+u(iw_mag(2))**2+u(iw_mag(3))**2)
     ! Compute momentum from density and velocity components
@@ -557,7 +556,7 @@ end subroutine addsource_compact
     flux(iw_mom(flux_dim))=flux(iw_mom(flux_dim))+ptotal
 
     ! Energy flux
-    flux(iw_e)=u(iw_mom(flux_dim))*(u(iw_e)/mhd_gamma_m1+0.5_dp*&
+    flux(iw_e)=u(iw_mom(flux_dim))*(u(iw_e)*inv_gamma_1+0.5_dp*&
       u(iw_rho)*(u(iw_mom(1))**2+u(iw_mom(2))**2+u(iw_mom(3))**2)+&
       2.0_dp*ptotal-u(iw_e))-u(iw_mag(flux_dim))*&
       (u(iw_mag(1))*u(iw_mom(1))+u(iw_mag(2))*u(iw_mom(2))+u(iw_mag(3))*u(iw_mom(3)))
@@ -619,7 +618,7 @@ pure real(dp) function get_pthermal(w, x) result(pth)
   real(dp), intent(in)  :: w(nw_phys)
   real(dp), intent(in)  :: x(1:ndim)
 
-  pth = (phys_gamma-1.0_dp)*(w(iw_e)-0.5_dp*sum(w(iw_mom(:))**2)/w(iw_rho) &
+  pth = gamma_1*(w(iw_e)-0.5_dp*sum(w(iw_mom(:))**2)/w(iw_rho) &
        -0.5_dp*(w(iw_mag(1))**2+w(iw_mag(2))**2+w(iw_mag(3))**2))
 end function get_pthermal
 #:enddef


### PR DESCRIPTION
… fastest. Most importantly, remove cell-wise 1/(gamma-1) computation from get_flux.